### PR TITLE
Change statistics_sensor to measurement and set it to 0 kWh at the end

### DIFF
--- a/custom_components/wnsm/base_sensor.py
+++ b/custom_components/wnsm/base_sensor.py
@@ -48,7 +48,6 @@ class BaseSensor(SensorEntity, ABC):
         self._attr_name = zaehlpunkt
         self._attr_icon = self._icon()
         self._attr_device_class = SensorDeviceClass.ENERGY
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
         self._attr_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
 
@@ -57,6 +56,10 @@ class BaseSensor(SensorEntity, ABC):
         self._state: int | str | None = None
         self._available: bool = True
         self._updatets: str | None = None
+
+    @property
+    def _attr_state_class(self):
+        return SensorStateClass.TOTAL_INCREASING
 
     @property
     def _id(self):

--- a/custom_components/wnsm/statistics_sensor.py
+++ b/custom_components/wnsm/statistics_sensor.py
@@ -1,7 +1,7 @@
 import logging
 
 from homeassistant.components.recorder import get_instance
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 
 from .api import Smartmeter
 from .base_sensor import BaseSensor
@@ -29,6 +29,10 @@ class StatisticsSensor(BaseSensor, SensorEntity):
     @staticmethod
     def statistics(s: str) -> str:
         return f'{s}_statistics'
+
+    @property
+    def _attr_state_class(self):
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self) -> str:
@@ -126,7 +130,7 @@ class StatisticsSensor(BaseSensor, SensorEntity):
                 await self._import_historical_data(smartmeter)
             else:
                 await self._import_statistics(smartmeter, start, _sum)
-
+            self._state = 0
             self._updatets = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
         except TimeoutError as e:
             self._available = False


### PR DESCRIPTION
After reading https://github.com/DarwinsBuddy/WienerNetzeSmartmeter/issues/119 I wondered what the difference in set up is for live vs. statistics sensor.

I remember, that @reox had troubles setting the state of the statistics entity of a smart meter to something not `None`.
This presumably leads to the reported warning.

In order to fix this I tried out setting the statistics sensor to `measurement` (since it's not quite `total_increasing`) and set its value to `0 kWh`, s.t. it has an entry in the entity registry of home assistant (which was not the case prior to that).

The warning in the energy dashboard is gone.

@reox Can you potentially confirm that I didn't break anything else with this change?