### PR TITLE
Check if historical data was returned

### DIFF
--- a/custom_components/wnsm/statistics_sensor.py
+++ b/custom_components/wnsm/statistics_sensor.py
@@ -175,6 +175,11 @@ class StatisticsSensor(BaseSensor, SensorEntity):
         for ts, usage in sorted(dates.items(), key=itemgetter(0)):
             total_usage += usage
             statistics.append(StatisticData(start=ts, sum=total_usage, state=usage))
+        
+        if len(statistics) == 0:
+             # No data is returned, possibly the smart meter is too new or not active yet...
+            _LOGGER.info("No historical data available for smart meter!")
+            return
 
         _LOGGER.debug(f"Importing statistics from {statistics[0]} to {statistics[-1]}")
         async_import_statistics(self.hass, metadata, statistics)


### PR DESCRIPTION
resolves #143

There is just one question now: In this case, the historical data import will be triggered every time until there is any data.
@DarwinsBuddy Should we write an empty statistics here to prevent the import the next time?