### PR TITLE
Bugfix/verbrauch

### DIFF
--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -235,9 +235,9 @@ class Smartmeter:
 
     def _get_first_zaehlpunkt(self) -> (str, str):
         zps = self.zaehlpunkte()[0]
-        customerId = zps["geschaeftspartner"]
+        customer_id = zps["geschaeftspartner"]
         zp = zps["zaehlpunkte"][0]["zaehlpunktnummer"]
-        return customerId, zp
+        return customer_id, zp
 
     def zaehlpunkte(self):
         """Returns zaehlpunkte for currently logged in user."""
@@ -281,7 +281,7 @@ class Smartmeter:
         if date_to is None:
             date_to = datetime.now()
         if zaehlpunkt is None or customer_id is None:
-            customerId, zaehlpunkt = self._get_first_zaehlpunkt()
+            customer_id, zaehlpunkt = self._get_first_zaehlpunkt()
         endpoint = f"messdaten/{customer_id}/{zaehlpunkt}/verbrauch"
         query = const.build_verbrauchs_args(
             dateFrom=self._dt_string(date_from),
@@ -317,7 +317,7 @@ class Smartmeter:
         if date_to is None:
             date_to = datetime.now()
         if zaehlpunkt is None or customer_id is None:
-            customerId, zaehlpunkt = self._get_first_zaehlpunkt()
+            customer_id, zaehlpunkt = self._get_first_zaehlpunkt()
         endpoint = f"messdaten/{customer_id}/{zaehlpunkt}/verbrauchRaw"
         query = const.build_verbrauchs_args(
             dateFrom=self._dt_string(date_from),
@@ -351,7 +351,7 @@ class Smartmeter:
         if date_to is None:
             date_to = datetime.now()
         if zaehlpunkt is None:
-            zaehlpunkt = self._get_first_zaehlpunkt()
+            customer_id, zaehlpunkt = self._get_first_zaehlpunkt()
         query = {
             "zaehlpunkt": zaehlpunkt,
             "dateFrom": self._dt_string(date_from),

--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -260,12 +260,13 @@ class Smartmeter:
         customer_id: str,
         zaehlpunkt: str,
         date_from: datetime,
-        date_to: datetime = None,
         resolution: const.Resolution = const.Resolution.HOUR
     ):
         """Returns energy usage.
-        This can be used to query the daily consumption for a long period of time,
-        for example several months or a week.
+
+        This returns hourly or quarter hour consumptions for a single day,
+        i.e., for 24 hours after the given date_from.
+
         Args:
             customer_id (str): Customer ID returned by zaehlpunkt call ("geschaeftspartner")
             zaehlpunkt (str, optional): id for desired smartmeter.
@@ -278,15 +279,12 @@ class Smartmeter:
             dict: JSON response of api call to
                 'messdaten/CUSTOMER_ID/ZAEHLPUNKT/verbrauchRaw'
         """
-        if date_to is None:
-            date_to = datetime.now()
         if zaehlpunkt is None or customer_id is None:
             customer_id, zaehlpunkt = self._get_first_zaehlpunkt()
         endpoint = f"messdaten/{customer_id}/{zaehlpunkt}/verbrauch"
         query = const.build_verbrauchs_args(
+            # This one does not have a dateTo...
             dateFrom=self._dt_string(date_from),
-            dateTo=self._dt_string(date_to),
-            granularity="DAY",
             dayViewResolution=resolution.value
         )
         return self._call_api(endpoint, query=query)
@@ -297,11 +295,14 @@ class Smartmeter:
         zaehlpunkt: str,
         date_from: datetime,
         date_to: datetime = None,
-        resolution: const.Resolution = const.Resolution.HOUR
     ):
         """Returns energy usage.
         This can be used to query the daily consumption for a long period of time,
         for example several months or a week.
+
+        Note: The minimal resolution is a single day.
+        For hourly consumptions use `verbrauch`.
+
         Args:
             customer_id (str): Customer ID returned by zaehlpunkt call ("geschaeftspartner")
             zaehlpunkt (str, optional): id for desired smartmeter.
@@ -309,7 +310,6 @@ class Smartmeter:
             date_from (datetime): Start date for energy usage request
             date_to (datetime, optional): End date for energy usage request.
                 Defaults to datetime.now()
-            resolution (const.Resolution, optional): Specify either 1h or 15min resolution
         Returns:
             dict: JSON response of api call to
                 'messdaten/CUSTOMER_ID/ZAEHLPUNKT/verbrauchRaw'
@@ -319,11 +319,11 @@ class Smartmeter:
         if zaehlpunkt is None or customer_id is None:
             customer_id, zaehlpunkt = self._get_first_zaehlpunkt()
         endpoint = f"messdaten/{customer_id}/{zaehlpunkt}/verbrauchRaw"
-        query = const.build_verbrauchs_args(
+        query = dict(
+            # These are the only three fields that are used for that endpoint:
             dateFrom=self._dt_string(date_from),
             dateTo=self._dt_string(date_to),
             granularity="DAY",
-            dayViewResolution=resolution.value
         )
         return self._call_api(endpoint, query=query)
 

--- a/custom_components/wnsm/base_sensor.py
+++ b/custom_components/wnsm/base_sensor.py
@@ -130,7 +130,7 @@ class BaseSensor(SensorEntity, ABC):
         return translate_dict(response, ATTRS_VERBRAUCH_CALL)
 
     async def get_consumption_raw(self, smartmeter: Smartmeter, start_date: datetime):
-        """Return 24h of hourly consumption starting from a date"""
+        """Return daily consumptions from the given start date until today"""
         response = await self.hass.async_add_executor_job(
             smartmeter.verbrauchRaw, self._attr_extra_state_attributes.get('customerId'), self.zaehlpunkt, start_date
         )

--- a/tests/it/__init__.py
+++ b/tests/it/__init__.py
@@ -363,11 +363,7 @@ def expect_zaehlpunkte(requests_mock: Mocker, zps: list[dict]):
 def expect_verbrauch(requests_mock: Mocker, customer_id: str, zp: str, dateFrom: dt.datetime, response: dict, granularity ='DAY', resolution ='HOUR'):
     params = {
         "dateFrom":     _dt_string(dateFrom),
-        "granularity":  granularity,
-        "dayViewResolution":   resolution,
-        "period":       "DAY",
-        "offset":       0,
-        "accumulate":   False
+        "dayViewResolution":   resolution
     }
     path = f'messdaten/{customer_id}/{zp}/verbrauch?{urlencode(params)}'
     print("MOCK: ", API_URL_B2C + path)

--- a/tests/it/__init__.py
+++ b/tests/it/__init__.py
@@ -360,10 +360,9 @@ def expect_zaehlpunkte(requests_mock: Mocker, zps: list[dict]):
                       json=zaehlpunkt_response(zps))
 
 @pytest.mark.usefixtures("requests_mock")
-def expect_verbrauch(requests_mock: Mocker, customer_id: str, zp: str, dateFrom: dt.datetime, dateTo: dt.datetime, response: dict, granularity ='DAY', resolution ='HOUR'):
+def expect_verbrauch(requests_mock: Mocker, customer_id: str, zp: str, dateFrom: dt.datetime, response: dict, granularity ='DAY', resolution ='HOUR'):
     params = {
         "dateFrom":     _dt_string(dateFrom),
-        "dateTo":       _dt_string(dateTo),
         "granularity":  granularity,
         "dayViewResolution":   resolution,
         "period":       "DAY",

--- a/tests/it/test_api.py
+++ b/tests/it/test_api.py
@@ -186,6 +186,6 @@ def test_verbrauch_raw(requests_mock: Mocker):
     expect_zaehlpunkte(requests_mock, [enabled(zaehlpunkt())])
     expect_verbrauch(requests_mock, customer_id, zp, dateFrom, valid_verbrauch_raw_response)
 
-    verbrauch = smartmeter().login().verbrauch(customer_id, zp, dateFrom, dateTo)
+    verbrauch = smartmeter().login().verbrauch(customer_id, zp, dateFrom)
 
     assert 7 == len(verbrauch['values'])

--- a/tests/it/test_api.py
+++ b/tests/it/test_api.py
@@ -184,7 +184,7 @@ def test_verbrauch_raw(requests_mock: Mocker):
     expect_login(requests_mock)
     expect_history(requests_mock, enabled(zaehlpunkt())['zaehlpunktnummer'])
     expect_zaehlpunkte(requests_mock, [enabled(zaehlpunkt())])
-    expect_verbrauch(requests_mock, customer_id, zp, dateFrom, dateTo, valid_verbrauch_raw_response)
+    expect_verbrauch(requests_mock, customer_id, zp, dateFrom, valid_verbrauch_raw_response)
 
     verbrauch = smartmeter().login().verbrauch(customer_id, zp, dateFrom, dateTo)
 


### PR DESCRIPTION
go back to `verbrauch` for 24h hourly data.
Clean up the API calls a bit.