### PR TITLE
Fix missing historical data in feed-in Zaehlerpunkt

### DIFF
--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -242,10 +242,12 @@ class Smartmeter:
         customer_id = zps["geschaeftspartner"]
         if zaehlpunkt is not None:
             zp = [z for z in zps["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
+            anlage_typ = zp[0]["anlage"]["typ"] if len(zp) > 0 else None
             zp = zp[0]["zaehlpunktnummer"] if len(zp) > 0 else None
         else:
             zp = zps["zaehlpunkte"][0]["zaehlpunktnummer"]
-        return customer_id, zp
+            anlage_typ = zps["zaehlpunkte"][0]["anlage"]["typ"]
+        return customer_id, zp, anlage_typ
 
     def zaehlpunkte(self):
         """Returns zaehlpunkte for currently logged in user."""
@@ -466,12 +468,18 @@ class Smartmeter:
         If no arguments are given, a span of three year is queried (same day as today but from current year - 3).
         If date_from is not given but date_until, again a three year span is assumed.
         """
-        if valuetype == const.ValueType.DAY:
-            rolle = "V001"
+        customer_id, zaehlpunkt,anlage_typ = self.get_zaehlpunkt(zaehlpunktnummer)
+        
+        if anlage_typ== "BEZUG":
+            if valuetype == const.ValueType.DAY:
+                rolle = "E001"
+            else:
+                rolle = "E002"
         else:
-            rolle = "V002"
-
-        customer_id, zaehlpunkt = self.get_zaehlpunkt(zaehlpunktnummer)
+            if valuetype == const.ValueType.DAY:
+                rolle = "V001"
+            else:
+                rolle = "V002"
 
         if date_until is None:
             date_until = date.today()

--- a/custom_components/wnsm/api/constants.py
+++ b/custom_components/wnsm/api/constants.py
@@ -51,6 +51,26 @@ class ValueType(enum.Enum):
         else:
             raise NotImplementedError
 
+class AnlageType(enum.Enum):
+    """Possible types for the zaehlpunkte"""
+    CONSUMING = "TAGSTROM"  #: Zaehlpunkt is consuming ("normal" power connection)
+    FEEDING = "BEZUG"  #: Zaehlpunkt is feeding (produced power from PV, etc.)
+    
+    @staticmethod
+    def from_str(label):
+        if label in ('TAGSTROM', 'tagstrom'):
+            return AnlageType.CONSUMING
+        elif label in ('BEZUG', 'bezug'):
+            return AnlageType.FEEDING
+        else:
+            raise NotImplementedError
+            
+class RoleType(enum.Enum):
+    """Possible types for the roles of bewegungsdaten - depending on the settings set in smart meter portal"""
+    DAILY_CONSUMING = "V001"  #: Consuming data is updated in daily steps
+    QUARTER_HOURLY_CONSUMING = "V002"  #: Consuming data is updated in quarter hour steps
+    DAILY_FEEDING = "E001"  #: Feeding data is updated in daily steps
+    QUARTER_HOURLY_FEEDING = "E002"  #: Feeding data is updated in quarter hour steps
 
 def build_access_token_args(**kwargs):
     """


### PR DESCRIPTION
Zaehlerpunkte which have the type "Bezug", have different roles in the URL for the API call used in the method bewegungsdaten, which are used for the statistics. The roles are E001 for daily or E002 for quarterly updates, instead of V001 and V002. 

This should resolve #223 