### PR TITLE
Fix multiple contracts/customer ids

### DIFF
--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -242,10 +242,12 @@ class Smartmeter:
         customer_id = zps["geschaeftspartner"]
         if zaehlpunkt is not None:
             zp = [z for z in zps["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
+            anlage_typ = zp[0]["anlage"]["typ"] if len(zp) > 0 else None
             zp = zp[0]["zaehlpunktnummer"] if len(zp) > 0 else None
         else:
             zp = zps["zaehlpunkte"][0]["zaehlpunktnummer"]
-        return customer_id, zp
+            anlage_typ = zps["zaehlpunkte"][0]["anlage"]["typ"]
+        return customer_id, zp, anlage_typ
 
     def zaehlpunkte(self):
         """Returns zaehlpunkte for currently logged in user."""
@@ -466,12 +468,18 @@ class Smartmeter:
         If no arguments are given, a span of three year is queried (same day as today but from current year - 3).
         If date_from is not given but date_until, again a three year span is assumed.
         """
-        if valuetype == const.ValueType.DAY:
-            rolle = "V001"
+        customer_id, zaehlpunkt,anlage_typ = self.get_zaehlpunkt(zaehlpunktnummer)
+        
+        if anlage_typ== "BEZUG":
+            if valuetype == const.ValueType.DAY:
+                rolle = "E001"
+            else:
+                rolle = "E002"
         else:
-            rolle = "V002"
-
-        customer_id, zaehlpunkt = self.get_zaehlpunkt(zaehlpunktnummer)
+            if valuetype == const.ValueType.DAY:
+                rolle = "V001"
+            else:
+                rolle = "V002"
 
         if date_until is None:
             date_until = date.today()

--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -238,15 +238,19 @@ class Smartmeter:
         return response.json()
 
     def get_zaehlpunkt(self, zaehlpunkt: str = None) -> tuple[str, str, str]:
-        zps = self.zaehlpunkte()[0]
-        customer_id = zps["geschaeftspartner"]
-        if zaehlpunkt is not None:
-            zp = [z for z in zps["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
-            anlagetype = zp[0]["anlage"]["typ"] if len(zp) > 0 else None
-            zp = zp[0]["zaehlpunktnummer"] if len(zp) > 0 else None
+        contracts = self.zaehlpunkte()
+        if zaehlpunkt is None:
+            customer_id = contracts[0]["geschaeftspartner"]
+            zp = contracts[0]["zaehlpunkte"][0]["zaehlpunktnummer"]
+            anlagetype = contracts[0]["zaehlpunkte"][0]["anlage"]["typ"]
         else:
-            zp = zps["zaehlpunkte"][0]["zaehlpunktnummer"]
-            anlagetype = zps["zaehlpunkte"][0]["anlage"]["typ"]
+            customer_id = zp = anlagetype = None
+            for contract in contracts:
+                zp = [z for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
+                if len(zp) > 0:
+                    anlagetype = zp[0]["anlage"]["typ"]
+                    zp = zp[0]["zaehlpunktnummer"]
+                    customer_id = contract["geschaeftspartner"]
         return customer_id, zp, const.AnlageType.from_str(anlagetype)
 
     def zaehlpunkte(self):

--- a/custom_components/wnsm/api/constants.py
+++ b/custom_components/wnsm/api/constants.py
@@ -51,6 +51,26 @@ class ValueType(enum.Enum):
         else:
             raise NotImplementedError
 
+class AnlageType(enum.Enum):
+    """Possible types for the zaehlpunkte"""
+    CONSUMING = "TAGSTROM"  #: Zaehlpunkt is consuming ("normal" power connection)
+    FEEDING = "BEZUG"  #: Zaehlpunkt is feeding (produced power from PV, etc.)
+    
+    @staticmethod
+    def from_str(label):
+        if label in ('TAGSTROM', 'tagstrom'):
+            return AnlageType.CONSUMING
+        elif label in ('BEZUG', 'bezug'):
+            return AnlageType.FEEDING
+        else:
+            raise NotImplementedError
+            
+class RoleType(enum.Enum):
+    """Possible types for the roles of bewegungsdaten - depending on the settings set in smart meter portal"""
+    DAILY_CONSUMING = "V001"  #: Consuming data is updated in daily steps
+    QUARTER_HOURLY_CONSUMING = "V002"  #: Consuming data is updated in quarter hour steps
+    DAILY_FEEDING = "E001"  #: Feeding data is updated in daily steps
+    QUARTER_HOURLY_FEEDING = "E002"  #: Feeding data is updated in quarter hour steps
 
 def build_access_token_args(**kwargs):
     """

--- a/custom_components/wnsm/base_sensor.py
+++ b/custom_components/wnsm/base_sensor.py
@@ -86,16 +86,17 @@ class BaseSensor(SensorEntity, ABC):
     def state(self) -> Optional[str]:  # pylint: disable=overridden-final-method
         return self._state
 
-    def contracts2zaehlpunkte(self, contracts: dict) -> [dict]:
-        if contracts is None or len(contracts) == 0:
-            raise RuntimeError(f"Cannot access Zaehlpunkt {self.zaehlpunkt}")
-        geschaeftspartner = contracts[0]["geschaeftspartner"] if "geschaeftspartner" in contracts[0] else None
-        if contracts is not None and isinstance(contracts, list) and len(contracts) > 0 and "zaehlpunkte" in contracts[0]:
-            zaehlpunkte = [
-                {**z, "geschaeftspartner": geschaeftspartner} for z in contracts[0]["zaehlpunkte"] if z["zaehlpunktnummer"] == self.zaehlpunkt
-            ]
+    def contracts2zaehlpunkte(self, contracts: dict) -> list[dict]:
+        zaehlpunkte = []
+        if contracts is not None and isinstance(contracts, list) and len(contracts) > 0:
+            for contract in contracts:
+                if "zaehlpunkte" in contract:
+                    geschaeftspartner = contract["geschaeftspartner"] if "geschaeftspartner" in contract else None
+                    zaehlpunkte += [
+                        {**z, "geschaeftspartner": geschaeftspartner} for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == self.zaehlpunkt
+                    ]
         else:
-            zaehlpunkte = []
+            raise RuntimeError(f"Cannot access Zaehlpunkt {self.zaehlpunkt}")
         return zaehlpunkte
 
     async def get_zaehlpunkt(self, smartmeter: Smartmeter) -> dict[str, str]:

--- a/custom_components/wnsm/config_flow.py
+++ b/custom_components/wnsm/config_flow.py
@@ -32,10 +32,14 @@ class WienerNetzeSmartMeterCustomConfigFlow(config_entries.ConfigFlow, domain=DO
         """
         smartmeter = Smartmeter(username, password)
         await self.hass.async_add_executor_job(smartmeter.login)
-        zps = await self.hass.async_add_executor_job(smartmeter.zaehlpunkte)
-        if zps is not None and isinstance(zps, list) and len(zps) > 0 and "zaehlpunkte" in zps[0]:
-            return zps[0]["zaehlpunkte"]
-        return []
+        contracts = await self.hass.async_add_executor_job(smartmeter.zaehlpunkte)
+        zaehlpunkte=[]
+        if contracts is not None and isinstance(contracts, list) and len(contracts) > 0:
+            for contract in contracts:
+                if "zaehlpunkte" in contract:
+                    zaehlpunkte+=contract["zaehlpunkte"]
+        return zaehlpunkte
+
 
     async def async_step_user(self, user_input: Optional[dict[str, Any]] = None):
         """Invoked when a user initiates a flow via the user interface."""


### PR DESCRIPTION
Based on PR #228 this fixes having multiple zaehlpunkte in different contracts. The selection of the customer id was hardcoded and was always assumed to be the 0 index, but in some edge cases customers can have multiple customer ids with one or more zaehlpunkte. This should fix #232.