### PR TITLE
Fixed having multiple contracts with multiple zps

### DIFF
--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -236,17 +236,17 @@ class Smartmeter:
         contracts = self.zaehlpunkte()
         if zaehlpunkt is None:
             customer_id = contracts[0]["geschaeftspartner"]
-            zp = contracts[0]["zaehlpunkte"][0]["zaehlpunktnummer"]
+            zaehlp = contracts[0]["zaehlpunkte"][0]["zaehlpunktnummer"]
             anlagetype = contracts[0]["zaehlpunkte"][0]["anlage"]["typ"]
         else:
             customer_id = zp = anlagetype = None
             for contract in contracts:
-                zp = [z for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
+                zaehlp = [z for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt and z['isActive']]
                 if len(zp) > 0:
                     anlagetype = zp[0]["anlage"]["typ"]
-                    zp = zp[0]["zaehlpunktnummer"]
+                    zaehlp = zp[0]["zaehlpunktnummer"]
                     customer_id = contract["geschaeftspartner"]
-        return customer_id, zp, const.AnlageType.from_str(anlagetype)
+        return customer_id, zaehlp, const.AnlageType.from_str(anlagetype)
 
     def zaehlpunkte(self):
         """Returns zaehlpunkte for currently logged in user."""

--- a/custom_components/wnsm/base_sensor.py
+++ b/custom_components/wnsm/base_sensor.py
@@ -93,7 +93,7 @@ class BaseSensor(SensorEntity, ABC):
                 if "zaehlpunkte" in contract:
                     geschaeftspartner = contract["geschaeftspartner"] if "geschaeftspartner" in contract else None
                     zaehlpunkte += [
-                        {**z, "geschaeftspartner": geschaeftspartner} for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == self.zaehlpunkt
+                        {**z, "geschaeftspartner": geschaeftspartner} for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == self.zaehlpunkt and z['isActive']
                     ]
         else:
             raise RuntimeError(f"Cannot access Zaehlpunkt {self.zaehlpunkt}")

--- a/custom_components/wnsm/config_flow.py
+++ b/custom_components/wnsm/config_flow.py
@@ -37,7 +37,9 @@ class WienerNetzeSmartMeterCustomConfigFlow(config_entries.ConfigFlow, domain=DO
         if contracts is not None and isinstance(contracts, list) and len(contracts) > 0:
             for contract in contracts:
                 if "zaehlpunkte" in contract:
-                    zaehlpunkte+=contract["zaehlpunkte"]
+                    for zaehlpunkt in contract["zaehlpunkte"]:              
+                        if zaehlpunkt['isActive']:
+                            zaehlpunkte+=[zaehlpunkt]
         return zaehlpunkte
 
 


### PR DESCRIPTION
When switching provider and contract holder a new contract number is given but the zaehlpunkt stays the same. The old one is set to inactive, but is still in the system, if the contracted is not fully deleted. This leads to a situation where the same zaehlpunkt is listed twice under different contracts, once active, once inactive. Currently the updates don't fully check for inactive zaehlpunkte, if the same zaehlpunkt is listed twice. This fix checks all contracts and if the zaehlpunkt is active before adding it, so it gets the correct customer id for retrieving all the data.


I had to revert this PR as I spotted some potential flaws afterwards. @tschoerk maybe you could look over them one more time?