### PR TITLE
Fixed get_zaehlpunkt returning empty zaehlpunkt with multiple contracts

### DIFF
--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -241,10 +241,10 @@ class Smartmeter:
         else:
             customer_id = zp = anlagetype = None
             for contract in contracts:
-                zp = [z for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
-                if len(zp) > 0:
-                    anlagetype = zp[0]["anlage"]["typ"]
-                    zp = zp[0]["zaehlpunktnummer"]
+                zp_details = [z for z in contract["zaehlpunkte"] if z["zaehlpunktnummer"] == zaehlpunkt]
+                if len(zp_details) > 0:
+                    anlagetype = zp_details[0]["anlage"]["typ"]
+                    zp = zp_details[0]["zaehlpunktnummer"]
                     customer_id = contract["geschaeftspartner"]
         return customer_id, zp, const.AnlageType.from_str(anlagetype)
 


### PR DESCRIPTION
When adding or updating a sensor, the zaehlpunkt is checked with the get_zaehlpunkt function. The problem was that the variable for the array, which has the zaehlpunkt details in them, had the same name as the zaehlpunkt itself. So when having multiple contracts/customerIds, the correct zaehlpunkt was overwritten by the zaehlpunkt details, which is now an empty array. All API requests were then done with an empty array and threw errors all around.

Probably fixes #267. The second error [ryanbrown-at](https://github.com/ryanbrown-at) describes, could be due to the recent API changes, which made verbrauch and verbrauch_raw stop working.