### PR TITLE
Fix/improve multiple Zaehlwerke/OBIS Codes

### DIFF
--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -405,14 +405,28 @@ class Smartmeter:
         """
         Find and validate data with valid OBIS codes from a list of zaehlwerke.
         """
+        
+        # Check if any OBIS codes exist
+        all_obis_codes = [zaehlwerk.get("obisCode") for zaehlwerk in zaehlwerke]
+        if not any(all_obis_codes):
+            raise SmartmeterQueryError("No OBIS codes found in the provided data.")
+        
+        # Filter data for valid OBIS codes
         valid_data = [
             zaehlwerk for zaehlwerk in zaehlwerke
-            if zaehlwerk.get("obisCode") in const.VALID_OBIS_CODES and "messwerte" in zaehlwerk
+            if zaehlwerk.get("obisCode") in const.VALID_OBIS_CODES
         ]
         
         if not valid_data:
-            all_obis_codes = [zaehlwerk.get("obisCode") for zaehlwerk in zaehlwerke]
             raise SmartmeterQueryError(f"No valid OBIS code found. OBIS codes in data: {all_obis_codes}")
+        
+        # Check for empty or missing messwerte
+        for zaehlwerk in valid_data:
+            if not zaehlwerk.get("messwerte"):
+                obis = zaehlwerk.get("obisCode")
+                logger.warning(f"Valid OBIS code '{obis}' has empty or missing messwerte.")
+                
+        # Log a warning if multiple valid OBIS codes are found        
         if len(valid_data) > 1:
             found_valid_obis = [zaehlwerk["obisCode"] for zaehlwerk in valid_data]
             logger.warning(f"Multiple valid OBIS codes found: {found_valid_obis}. Using the first one.")

--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -409,6 +409,7 @@ class Smartmeter:
         # Check if any OBIS codes exist
         all_obis_codes = [zaehlwerk.get("obisCode") for zaehlwerk in zaehlwerke]
         if not any(all_obis_codes):
+            logger.debug("Returned zaehlwerke: %s", zaehlwerke)
             raise SmartmeterQueryError("No OBIS codes found in the provided data.")
         
         # Filter data for valid OBIS codes
@@ -418,13 +419,14 @@ class Smartmeter:
         ]
         
         if not valid_data:
+            logger.debug("Returned zaehlwerke: %s", zaehlwerke)
             raise SmartmeterQueryError(f"No valid OBIS code found. OBIS codes in data: {all_obis_codes}")
         
         # Check for empty or missing messwerte
         for zaehlwerk in valid_data:
             if not zaehlwerk.get("messwerte"):
                 obis = zaehlwerk.get("obisCode")
-                logger.warning(f"Valid OBIS code '{obis}' has empty or missing messwerte.")
+                logger.debug(f"Valid OBIS code '{obis}' has empty or missing messwerte. Data is probably not available yet.")
                 
         # Log a warning if multiple valid OBIS codes are found        
         if len(valid_data) > 1:
@@ -438,7 +440,7 @@ class Smartmeter:
         zaehlpunktnummer: str = None,
         date_from: date = None,
         date_until: date = None,
-        valuetype: const.ValueType = const.ValueType.QUARTER_HOUR,
+        valuetype: const.ValueType = const.ValueType.METER_READ
     ):
         """
         Query historical data in a batch
@@ -481,13 +483,13 @@ class Smartmeter:
         # Sanity check: Validate returned zaehlpunkt
         if data.get("zaehlpunkt") != zaehlpunkt:
             logger.debug("Returned data: %s", data)
-            raise SmartmeterQueryError("Returned data does not match the given Zählpunkt.")
+            raise SmartmeterQueryError("Returned data does not match given zaehlpunkt!")
 
         # Validate and extract valid OBIS data
         zaehlwerke = data.get("zaehlwerke")
         if not zaehlwerke:
             logger.debug("Returned data: %s", data)
-            raise SmartmeterQueryError("Returned data does not contain any Zählwerke or is empty.")
+            raise SmartmeterQueryError("Returned data does not contain any zaehlwerke or is empty.")
 
         valid_obis_data = self.find_valid_obis_data(zaehlwerke)
         return valid_obis_data

--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -401,7 +401,7 @@ class Smartmeter:
         """Deletes ereignis."""
         return self._call_api(f"user/ereignis/{ereignis_id}", method="DELETE")
 
-    def find_valid_obis_data(zaehlwerke: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def find_valid_obis_data(self, zaehlwerke: List[Dict[str, Any]]) -> Dict[str, Any]:
         """
         Find and validate data with valid OBIS codes from a list of zaehlwerke.
         """

--- a/custom_components/wnsm/api/constants.py
+++ b/custom_components/wnsm/api/constants.py
@@ -24,10 +24,10 @@ LOGIN_ARGS = {
 }
 
 VALID_OBIS_CODES = {
-    "1-1:1.8.0", #: Sum of consumption in kWh - used by Wiener Netze as default
-    "1-1:1.9.0", #: Sum of consumption in kWh - used by Wiener Netze for heat pumps - per standard this should be the default
-    "1-1:2.8.0", #: Sum of production in kWh - used by Wiener Netzte as default
-    "1-1:2.9.0" #: Sum of production in kWh - currently unused - per standard this should be the default
+    "1-1:1.8.0", #: Total Meter reading of consumption in Wh on selected day(s)- updated daily - used by Wiener Netze as default for meter reading ("Zählerstand")
+    "1-1:1.9.0", #: Measured value of consumption in Wh in quarter hour or daily steps - updated daily - also used by Wiener Netze for meter readings of heat pumps
+    "1-1:2.8.0", #: Total Meter reading of production/feeding on selected day(s) in Wh - used by Wiener Netze as default for meter reading ("Zählerstand")
+    "1-1:2.9.0" #: Measured value of production/feeding in Wh in quarter hour or daily steps - updated daily - currently unused by Wiener Netze but accesible via API (call to zaehlpunkte/{customer_id}/{zaehlpunkt}/messwerte with ValueType DAY or QUARTER_HOUR)
 }
 
 class Resolution(enum.Enum):

--- a/custom_components/wnsm/api/constants.py
+++ b/custom_components/wnsm/api/constants.py
@@ -23,6 +23,12 @@ LOGIN_ARGS = {
     "nonce": "",
 }
 
+VALID_OBIS_CODES = {
+    "1-1:1.8.0", #: Sum of consumption in kWh - used by Wiener Netze as default
+    "1-1:1.9.0", #: Sum of consumption in kWh - used by Wiener Netze for heat pumps - per standard this should be the default
+    "1-1:2.8.0", #: Sum of production in kWh - used by Wiener Netzte as default
+    "1-1:2.9.0" #: Sum of production in kWh - currently unused - per standard this should be the default
+}
 
 class Resolution(enum.Enum):
     """Possible resolution for consumption data of one day"""


### PR DESCRIPTION
Implemented the ability to check different valid OBIS codes. Wiener Netze is currently using two OBIS codes as default for meter readings 1-1:1.8.0 for consumption and 1-1:2.8.0 for production. Apparently they started using 1-1:1.9.0 especially for people using heat pumps, which is the sum of 1-1:1.8.1 and 1-1:1.8.2. Since there was basically no checking of valid OBIS codes, except if there's only one present (the amount was 3 in the case of heat pumps, therefore an error was thrown), this heavily improves upon this.

This fixes #272 