### PR TITLE
Update importer.py - add unit_class

### DIFF
--- a/custom_components/wnsm/importer.py
+++ b/custom_components/wnsm/importer.py
@@ -131,6 +131,7 @@ class Importer:
             name=self.zaehlpunkt,
             unit_of_measurement=self.unit_of_measurement,
             has_mean=False,
+            unit_class="energy",
             has_sum=True,
         )
 

--- a/custom_components/wnsm/importer.py
+++ b/custom_components/wnsm/importer.py
@@ -13,7 +13,10 @@ from homeassistant.components.recorder.statistics import (
     get_last_statistics, async_add_external_statistics,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
+from homeassistant.util import (
+    dt as dt_util,
+    unit_conversion
+)
 
 from .AsyncSmartmeter import AsyncSmartmeter
 from .api.constants import ValueType
@@ -131,7 +134,7 @@ class Importer:
             name=self.zaehlpunkt,
             unit_of_measurement=self.unit_of_measurement,
             has_mean=False,
-            unit_class="energy",
+            unit_class=EnergyConverter.UNIT_CLASS,
             has_sum=True,
         )
 

--- a/custom_components/wnsm/importer.py
+++ b/custom_components/wnsm/importer.py
@@ -13,10 +13,9 @@ from homeassistant.components.recorder.statistics import (
     get_last_statistics, async_add_external_statistics,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util import (
-    dt as dt_util,
-    unit_conversion
-)
+from homeassistant.util import dt as dt_util
+
+from homeassistant.util.unit_conversion import EnergyConverter
 
 from .AsyncSmartmeter import AsyncSmartmeter
 from .api.constants import ValueType


### PR DESCRIPTION
Fixes warning message: "Detected that custom integration 'wnsm' doesn't specify unit_class when calling async_add_external_statistics at custom_components/wnsm/importer.py, line 208: async_add_external_statistics(self.hass, metadata, statistics). This will stop working in Home Assistant 2026.11, please create a bug report at https://github.com/DarwinsBuddy/WienerNetzeSmartmeter/issues"
Info here: https://developers.home-assistant.io/blog/2025/10/16/recorder-statistics-api-changes/

This should fix #334