### PR TITLE
Added support for EEGs

### DIFF
--- a/custom_components/wnsm/AsyncSmartmeter.py
+++ b/custom_components/wnsm/AsyncSmartmeter.py
@@ -138,19 +138,58 @@ class AsyncSmartmeter:
                 or zaehlpunkt_response["smartMeterReady"]
         )
 
-    async def get_bewegungsdaten(self, zaehlpunkt: str, start: datetime = None, end: datetime = None, granularity: ValueType = ValueType.QUARTER_HOUR):
+    async def get_bewegungsdaten(self, zaehlpunkt: str, start: datetime = None, end: datetime = None, granularity: ValueType = ValueType.QUARTER_HOUR, rolle: str = None):
         """Return three years of historic quarter-hourly data"""
         response = await self.hass.async_add_executor_job(
             self.smartmeter.bewegungsdaten,
             zaehlpunkt,
             start,
             end,
-            granularity
+            granularity,
+            None,
+            rolle
         )
         if "Exception" in response:
             raise RuntimeError(f"Cannot access bewegungsdaten: {response}")
         _LOGGER.debug(f"Raw bewegungsdaten: {response}")
         return translate_dict(response, ATTRS_BEWEGUNGSDATEN)
+
+    async def get_zaehlwerke(self, zaehlpunkt: str) -> dict:
+        """
+        asynchronously get the /zaehlwerke response (profile roles + eagTeilnahmen)
+        """
+        response = await self.hass.async_add_executor_job(
+            self.smartmeter.zaehlwerke,
+            None,
+            zaehlpunkt
+        )
+        if "Exception" in response:
+            raise RuntimeError(f"Cannot access zaehlwerke: {response}")
+        return response
+
+    async def has_energiegemeinschaft(self, zaehlpunkt: str) -> bool:
+        """
+        Returns True if the zaehlpunkt has an active Energiegemeinschaft
+        participation (eagTeilnahmen entry with status 'A' covering today).
+        Detection is best-effort and must never break the regular update.
+        """
+        try:
+            zaehlwerke = await self.get_zaehlwerke(zaehlpunkt)
+        except (RuntimeError, KeyError, TimeoutError) as e:
+            _LOGGER.debug("Could not determine Energiegemeinschaft participation: %s", e)
+            return False
+        today = datetime.now().date()
+        for teilnahme in zaehlwerke.get("eagTeilnahmen", []) or []:
+            if teilnahme.get("status") != "A":
+                continue
+            try:
+                date_from = datetime.strptime(teilnahme["dateFrom"], "%Y-%m-%d").date()
+                date_to = datetime.strptime(teilnahme["dateTo"], "%Y-%m-%d").date()
+            except (KeyError, ValueError):
+                continue
+            if date_from <= today <= date_to:
+                return True
+        return False
 
     async def get_consumptions(self) -> dict[str, str]:
         """

--- a/custom_components/wnsm/api/client.py
+++ b/custom_components/wnsm/api/client.py
@@ -588,6 +588,7 @@ class Smartmeter:
         date_until: date = None,
         valuetype: const.ValueType = const.ValueType.QUARTER_HOUR,
         aggregat: str = None,
+        rolle: str = None,
     ):
         """
         Query historical data in a batch
@@ -596,16 +597,17 @@ class Smartmeter:
         """
         customer_id, zaehlpunkt, anlagetype = self.get_zaehlpunkt(zaehlpunktnummer)
 
-        if anlagetype == const.AnlagenType.FEEDING:
-            if valuetype == const.ValueType.DAY:
-                rolle = const.RoleType.DAILY_FEEDING.value
+        if rolle is None:
+            if anlagetype == const.AnlagenType.FEEDING:
+                if valuetype == const.ValueType.DAY:
+                    rolle = const.RoleType.DAILY_FEEDING.value
+                else:
+                    rolle = const.RoleType.QUARTER_HOURLY_FEEDING.value
             else:
-                rolle = const.RoleType.QUARTER_HOURLY_FEEDING.value
-        else:
-            if valuetype == const.ValueType.DAY:
-                rolle = const.RoleType.DAILY_CONSUMING.value
-            else:
-                rolle = const.RoleType.QUARTER_HOURLY_CONSUMING.value
+                if valuetype == const.ValueType.DAY:
+                    rolle = const.RoleType.DAILY_CONSUMING.value
+                else:
+                    rolle = const.RoleType.QUARTER_HOURLY_CONSUMING.value
 
         if date_until is None:
             date_until = date.today()
@@ -636,3 +638,28 @@ class Smartmeter:
         if data["descriptor"]["zaehlpunktnummer"] != zaehlpunkt:
             raise SmartmeterQueryError("Returned data does not match given zaehlpunkt!")
         return data
+
+    def zaehlwerke(
+        self,
+        customer_id: str = None,
+        zaehlpunktnummer: str = None,
+    ):
+        """Returns the zaehlwerke metadata for a zaehlpunkt.
+
+        Besides the available profile roles this also contains the
+        'eagTeilnahmen' list, which describes active Energiegemeinschaft
+        participations (status 'A' with a date range covering today).
+        """
+        if zaehlpunktnummer is None or customer_id is None:
+            customer_id, zaehlpunktnummer, anlagetype = self.get_zaehlpunkt(zaehlpunktnummer)
+
+        extra = {
+            # For this API Call, requesting json is important!
+            "Accept": "application/json"
+        }
+
+        return self._call_api(
+            f"user/zaehlpunkte/{customer_id}/{zaehlpunktnummer}/zaehlwerke",
+            base_url=const.API_URL_ALT,
+            extra_headers=extra,
+        )

--- a/custom_components/wnsm/api/constants.py
+++ b/custom_components/wnsm/api/constants.py
@@ -75,6 +75,8 @@ class RoleType(enum.Enum):
     QUARTER_HOURLY_CONSUMING = "V002"  #: Consuming data is updated in quarter hour steps
     DAILY_FEEDING = "E001"  #: Feeding data is updated in daily steps
     QUARTER_HOURLY_FEEDING = "E002"  #: Feeding data is updated in quarter hour steps
+    GRID_CONSUMING = "G001"  #: Energiegemeinschaft: consumption drawn from the grid (quarter hour)
+    EEG_CONSUMING = "G003"  #: Energiegemeinschaft: consumption supplied by the energy community (quarter hour)
 
 def build_access_token_args(**kwargs):
     """

--- a/custom_components/wnsm/importer.py
+++ b/custom_components/wnsm/importer.py
@@ -26,13 +26,15 @@ _LOGGER = logging.getLogger(__name__)
 
 class Importer:
 
-    def __init__(self, hass: HomeAssistant, async_smartmeter: AsyncSmartmeter, zaehlpunkt: str, unit_of_measurement: str, granularity: ValueType = ValueType.QUARTER_HOUR):
-        self.id = f'{DOMAIN}:{zaehlpunkt.lower()}'
+    def __init__(self, hass: HomeAssistant, async_smartmeter: AsyncSmartmeter, zaehlpunkt: str, unit_of_measurement: str, granularity: ValueType = ValueType.QUARTER_HOUR, statistic_suffix: str = "", rolle: str = None):
+        self.id = f'{DOMAIN}:{zaehlpunkt.lower()}{statistic_suffix}'
         self.zaehlpunkt = zaehlpunkt
         self.granularity = granularity
         self.unit_of_measurement = unit_of_measurement
         self.hass = hass
         self.async_smartmeter = async_smartmeter
+        self.statistic_suffix = statistic_suffix
+        self.rolle = rolle
 
     def is_last_inserted_stat_valid(self, last_inserted_stat):
         return len(last_inserted_stat) == 1 and len(last_inserted_stat[self.id]) == 1 and \
@@ -131,7 +133,7 @@ class Importer:
         return StatisticMetaData(
             source=DOMAIN,
             statistic_id=self.id,
-            name=self.zaehlpunkt,
+            name=f"{self.zaehlpunkt}{self.statistic_suffix}",
             unit_of_measurement=self.unit_of_measurement,
             mean_type=StatisticMeanType.NONE,
             unit_class=EnergyConverter.UNIT_CLASS,
@@ -158,7 +160,7 @@ class Importer:
             _LOGGER.warning(f"Ignoring async update since last import happened in the future (should not happen) {start} > {end}")
             return None
 
-        bewegungsdaten = await self.async_smartmeter.get_bewegungsdaten(self.zaehlpunkt, start, end, self.granularity)
+        bewegungsdaten = await self.async_smartmeter.get_bewegungsdaten(self.zaehlpunkt, start, end, self.granularity, self.rolle)
         _LOGGER.debug(f"Mapped historical data: {bewegungsdaten}")
         if bewegungsdaten['unitOfMeasurement'] is None:
             _LOGGER.warning("Unit of measurement is None! Aborting import...")

--- a/custom_components/wnsm/wnsm_sensor.py
+++ b/custom_components/wnsm/wnsm_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.util import slugify
 
 from .AsyncSmartmeter import AsyncSmartmeter
 from .api import Smartmeter
-from .api.constants import ValueType
+from .api.constants import RoleType, ValueType
 from .importer import Importer
 from .utils import before, today
 
@@ -97,6 +97,13 @@ class WNSMSensor(SensorEntity):
                     self._attr_native_value = meter_reading
                 importer = Importer(self.hass, async_smartmeter, self.zaehlpunkt, self.unit_of_measurement, self.granularity())
                 await importer.async_import()
+                if await async_smartmeter.has_energiegemeinschaft(self.zaehlpunkt):
+                    for suffix, rolle in (
+                        ("_grid", RoleType.GRID_CONSUMING.value),
+                        ("_eeg", RoleType.EEG_CONSUMING.value),
+                    ):
+                        eeg_importer = Importer(self.hass, async_smartmeter, self.zaehlpunkt, self.unit_of_measurement, ValueType.QUARTER_HOUR, statistic_suffix=suffix, rolle=rolle)
+                        await eeg_importer.async_import()
             self._available = True
             self._updatets = datetime.now().strftime("%d.%m.%Y %H:%M:%S")
         except TimeoutError as e:

--- a/tests/it/__init__.py
+++ b/tests/it/__init__.py
@@ -308,6 +308,32 @@ def history_response(
 
     return {"zaehlwerke": zaehlwerke, "zaehlpunkt": zp}
     
+def zaehlwerke_response(customer_id: str, zp: str, eag_teilnahmen=None, wrong_zp: bool = False):
+    if wrong_zp:
+        zp = zp + "9"
+    resp = {
+        "geschaeftspartner": customer_id,
+        "zaehlpunktnummer": zp,
+        "granularities": [
+            {"granularity": "QH", "dateFrom": "2024-11-30T23:00:00Z", "dateTo": "9999-12-31T22:59:59Z"},
+        ],
+        "zaehlwerke": [
+            {"kennziffer": "1-1:1.9.0", "profiles": [
+                {"profile": "000000001001296766", "granularity": "QH", "profileRole": "V002"},
+            ]},
+            {"kennziffer": "1-1:1.9.0 P.01", "profiles": [
+                {"profile": "000000001001765015", "granularity": "QH", "profileRole": "G001"},
+            ]},
+            {"kennziffer": "1-1:2.9.0 G.03", "profiles": [
+                {"profile": "000000001001765011", "granularity": "QH", "profileRole": "G003"},
+            ]},
+        ],
+    }
+    if eag_teilnahmen is not None:
+        resp["eagTeilnahmen"] = eag_teilnahmen
+    return resp
+
+
 def delta(i: str, n: int=0) -> timedelta:
     return {
         "h":  timedelta(hours=n),
@@ -361,6 +387,17 @@ def bewegungsdaten_response(customer_id: str, zp: str,
         },
         "values": values
     }
+
+
+@pytest.mark.usefixtures("requests_mock")
+def expect_zaehlwerke(requests_mock: Mocker, customer_id: str, zp: str, eag_teilnahmen=None, wrong_zp: bool = False):
+    path = f'user/zaehlpunkte/{customer_id}/{zp}/zaehlwerke'
+    requests_mock.get(parse.urljoin(API_URL_ALT, path),
+                      headers={
+                          "Authorization": f"Bearer {ACCESS_TOKEN}",
+                          "Accept": "application/json"
+                      },
+                      json=zaehlwerke_response(customer_id, zp, eag_teilnahmen, wrong_zp))
 
 
 def smartmeter(username=USERNAME, password=PASSWORD, code_verifier=CODE_VERIFIER):
@@ -574,17 +611,18 @@ def expect_history(
 @pytest.mark.usefixtures("requests_mock")
 def expect_bewegungsdaten(requests_mock: Mocker, customer_id: str, zp: str, dateFrom: dt.datetime, dateTo: dt.datetime,
                           granularity:ValueType = ValueType.QUARTER_HOUR, anlagetype: AnlagenType = AnlagenType.CONSUMING,
-                          wrong_zp: bool = False, values_count=10):
-    if anlagetype== AnlagenType.FEEDING:
-        if granularity == ValueType.DAY: 
-            rolle = RoleType.DAILY_FEEDING.value 
+                          wrong_zp: bool = False, values_count=10, rolle: str = None):
+    if rolle is None:
+        if anlagetype== AnlagenType.FEEDING:
+            if granularity == ValueType.DAY:
+                rolle = RoleType.DAILY_FEEDING.value
+            else:
+                rolle = RoleType.QUARTER_HOURLY_FEEDING.value
         else:
-            rolle = RoleType.QUARTER_HOURLY_FEEDING.value 
-    else: 
-        if granularity == ValueType.DAY: 
-            rolle = RoleType.DAILY_CONSUMING.value 
-        else: 
-            rolle = RoleType.QUARTER_HOURLY_CONSUMING.value
+            if granularity == ValueType.DAY:
+                rolle = RoleType.DAILY_CONSUMING.value
+            else:
+                rolle = RoleType.QUARTER_HOURLY_CONSUMING.value
     params = {
         "geschaeftspartner": customer_id,
         "zaehlpunktnummer": zp,

--- a/tests/it/test_api.py
+++ b/tests/it/test_api.py
@@ -23,6 +23,7 @@ from it import (
     mock_token,
     mock_get_api_key,
     expect_history, expect_bewegungsdaten, zaehlpunkt_response,
+    expect_zaehlwerke,
 )
 from wnsm.api.errors import SmartmeterConnectionError, SmartmeterLoginError, SmartmeterQueryError
 import wnsm.api.constants as const
@@ -435,3 +436,51 @@ def test_verbrauch_raw(requests_mock: Mocker):
     verbrauch = smartmeter().login().verbrauch(customer_id, zp, dateFrom)
 
     assert 7 == len(verbrauch['values'])
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_zaehlwerke(requests_mock: Mocker):
+    z = zaehlpunkt_response([enabled(zaehlpunkt())])[0]
+    zp = z["zaehlpunkte"][0]['zaehlpunktnummer']
+    customer_id = z["geschaeftspartner"]
+    expect_login(requests_mock)
+    expect_zaehlpunkte(requests_mock, [enabled(zaehlpunkt())])
+    expect_zaehlwerke(requests_mock, customer_id, zp,
+                      eag_teilnahmen=[{"status": "A", "dateFrom": "2026-02-04", "dateTo": "9999-12-31"}])
+
+    zw = smartmeter().login().zaehlwerke()
+
+    assert zp == zw['zaehlpunktnummer']
+    assert [{"status": "A", "dateFrom": "2026-02-04", "dateTo": "9999-12-31"}] == zw['eagTeilnahmen']
+    roles = {p['profileRole'] for w in zw['zaehlwerke'] for p in w['profiles']}
+    assert {'V002', 'G001', 'G003'} <= roles
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_zaehlwerke_with_zp(requests_mock: Mocker):
+    z = zaehlpunkt_response([enabled(zaehlpunkt())])[0]
+    zp = z["zaehlpunkte"][0]['zaehlpunktnummer']
+    customer_id = z["geschaeftspartner"]
+    expect_login(requests_mock)
+    expect_zaehlwerke(requests_mock, customer_id, zp)
+
+    zw = smartmeter().login().zaehlwerke(customer_id, zp)
+
+    assert zp == zw['zaehlpunktnummer']
+    assert 'eagTeilnahmen' not in zw
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_bewegungsdaten_explicit_role(requests_mock: Mocker):
+    z = zaehlpunkt_response([enabled(zaehlpunkt())])[0]
+    dateFrom = dt.datetime(2023, 4, 21, 00, 00, 00, 0)
+    dateTo = dt.datetime(2023, 5, 1, 23, 59, 59, 999999)
+    zpn = z["zaehlpunkte"][0]['zaehlpunktnummer']
+    expect_login(requests_mock)
+    expect_bewegungsdaten(requests_mock, z["geschaeftspartner"], zpn, dateFrom, dateTo,
+                          const.ValueType.QUARTER_HOUR, values_count=COUNT, rolle="G003")
+    expect_zaehlpunkte(requests_mock, [enabled(zaehlpunkt())])
+
+    hist = smartmeter().login().bewegungsdaten(None, dateFrom, dateTo, const.ValueType.QUARTER_HOUR, None, "G003")
+
+    assert 10 == len(hist['values'])

--- a/tests/it/test_async.py
+++ b/tests/it/test_async.py
@@ -1,0 +1,54 @@
+"""AsyncSmartmeter tests"""
+import asyncio
+
+import pytest
+from requests_mock import Mocker
+
+from it import (
+    expect_login,
+    expect_zaehlpunkte,
+    expect_zaehlwerke,
+    smartmeter,
+    zaehlpunkt,
+    zaehlpunkt_response,
+    enabled,
+)
+from wnsm.AsyncSmartmeter import AsyncSmartmeter
+
+
+class FakeHass:
+    """Minimal hass stub: run executor jobs inline."""
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+def detect(requests_mock: Mocker, eag_teilnahmen):
+    z = zaehlpunkt_response([enabled(zaehlpunkt())])[0]
+    zp = z["zaehlpunkte"][0]['zaehlpunktnummer']
+    customer_id = z["geschaeftspartner"]
+    expect_login(requests_mock)
+    expect_zaehlpunkte(requests_mock, [enabled(zaehlpunkt())])
+    expect_zaehlwerke(requests_mock, customer_id, zp, eag_teilnahmen=eag_teilnahmen)
+    async_smartmeter = AsyncSmartmeter(FakeHass(), smartmeter().login())
+    return asyncio.run(async_smartmeter.has_energiegemeinschaft(zp))
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_has_energiegemeinschaft_active(requests_mock: Mocker):
+    assert detect(requests_mock, [{"status": "A", "dateFrom": "2020-01-01", "dateTo": "9999-12-31"}])
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_has_energiegemeinschaft_missing(requests_mock: Mocker):
+    assert not detect(requests_mock, None)
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_has_energiegemeinschaft_status_not_active(requests_mock: Mocker):
+    assert not detect(requests_mock, [{"status": "B", "dateFrom": "2020-01-01", "dateTo": "9999-12-31"}])
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_has_energiegemeinschaft_expired(requests_mock: Mocker):
+    assert not detect(requests_mock, [{"status": "A", "dateFrom": "2020-01-01", "dateTo": "2020-12-31"}])


### PR DESCRIPTION
## Energiegemeinschaft: grid/community consumption split

Adds EEG consumption side support for #310. Supersedes the approach in #343.

### What

For Zählpunkte participating in an Energiegemeinschaft (EEG), additionally
import the grid/community consumption split as **two new external
statistics**, alongside the existing total:

- `wnsm:<zp>` — unchanged (total consumption, V001/V002)
- `wnsm:<zp>_grid` — grid draw, role **G001** (Restnetzbezug)
- `wnsm:<zp>_eeg` — supplied by the community, role **G003** (Eigendeckung)

`G001 + G003 = V002` (per the role mapping established by @tschoerk and
confirmed by @AndiVienna91 in #310). Users wire `_grid`/`_eeg` into the
Energy Dashboard as two grid-consumption sources with separate prices.

### Auto-detection, no config flow

Participation is detected via the existing
`user/zaehlpunkte/{gp}/{zp}/zaehlwerke` endpoint: an `eagTeilnahmen` entry
with `status == "A"` whose date range covers today. Detection failures are
swallowed to debug — they can never break a normal update.

### Testing

- Live-validated against a real EEG account: descriptor matched the main
  ZP (no `SmartmeterQueryError`), three importers ran, `_grid`/`_eeg`
  statistics created, `G001 + G003 ≈ V002`.
- Only tested with consumption EEG. Sadly don't have access to the flip side
- Only tested with one EEG and haven't tested leaving one

### Scope & honest caveats

- **Consumption only.** Feed-in roles (U001 / E002−U001) deferred —
  issue consensus is solid only on G001/G003; W-M-B's feed-in roles are
  ambiguous (U001 vs U01T).
- **OBIS path untouched.** `find_valid_obis_data` is a different
  endpoint/concern; deliberately not modified (minimality).
- **Estimated/late-corrected data.** EEG values arrive 2 days–weeks late
  and `geschaetzt`; the incremental importer won't re-pull revised
  values, so the most recent weeks of `_grid`/`_eeg` can differ slightly
  from the WN portal. Pre-existing incremental behaviour, more visible
  for EEG.
- **Leaving an EEG.** Detection cuts on `dateTo < today`; due to WN's
  data lag the final stretch may never import. A `dateTo + grace` window
  is a possible future refinement.
