### PR TITLE
feat: add official OAuth2 API support alongside legacy scraper

### DIFF
--- a/Export_WN_SMART_METER_API.json
+++ b/Export_WN_SMART_METER_API.json
@@ -1,0 +1,523 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "WN_SMART_METER_API",
+    "description" : "Diese API ermöglicht Kunden, die sich zusätzlich mit OAUTH2 Token authentizieren, den Bezug von Anlagedaten und Verbauchswerten.\nZur Verfügung stehen sowohl allgemeine Aufrufe nur mit der Geschäftspartnernummer als auch gezielte zählpunktscharfe Anfragen.\n",
+    "contact" : {
+      "name" : "IPS Smart Meter",
+      "url" : "https://wienernetze.at",
+      "email" : "support.sm-portal@wienit.at"
+    },
+    "license" : {
+      "name" : "Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)",
+      "url" : "https://creativecommons.org/licenses/by-nc-nd/4.0/"
+    },
+    "version" : "1.0"
+  },
+  "servers" : [ {
+    "url" : "https://api.wstw.at/gateway/WN_SMART_METER_API/1.0"
+  } ],
+  "tags" : [ ],
+  "paths" : {
+    "/zaehlpunkte" : {
+      "summary" : "",
+      "description" : "",
+      "get" : {
+        "summary" : "",
+        "description" : "",
+        "operationId" : "getZaehlpunkteAnlagendaten",
+        "parameters" : [ {
+          "name" : "resultType",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "zaehlpunkt",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "webProfileId",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/zaehlpunkte_GET_response"
+                },
+                "example" : null
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "401" : {
+            "description" : "Access Denied"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not found"
+          }
+        },
+        "security" : [ { } ]
+      }
+    },
+    "/zaehlpunkte/messwerte" : {
+      "summary" : "",
+      "description" : "",
+      "get" : {
+        "summary" : "",
+        "description" : "",
+        "operationId" : "getZaehlpunkteMesswerte",
+        "parameters" : [ {
+          "name" : "datumBis",
+          "in" : "query",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "datumVon",
+          "in" : "query",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "wertetyp",
+          "in" : "query",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "webProfileId",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "zaehlpunkt",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/zaehlpunktemesswerte_GET_response"
+                },
+                "example" : null
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Access Denied"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not found"
+          }
+        },
+        "security" : [ { } ]
+      }
+    },
+    "/zaehlpunkte/{zaehlpunkt}" : {
+      "summary" : "",
+      "description" : "",
+      "get" : {
+        "summary" : "",
+        "description" : "",
+        "operationId" : "getZaehlpunktAnlagendaten",
+        "parameters" : [ {
+          "name" : "webProfileId",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "zaehlpunkt",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/zaehlpunktezaehlpunkt_GET_response"
+                },
+                "example" : "{\"anlage\":{\"anlage\":\"qmJKYGFO\",\"sparte\":\"AIhppuK\",\"typ\":\"XrPihMf\"},\"geraet\":{\"equipmentnummer\":\"B\",\"geraetenummer\":\"uuT\"},\"idex\":{\"customerInterface\":\"vbpuqgwNlbh\",\"displayLocked\":false,\"granularity\":\"tT\"},\"verbrauchsstelle\":{\"haus\":\"FfkdVHkrkN\",\"hausnummer1\":\"\",\"hausnummer2\":\"\",\"land\":\"jsBEdOhiYlMKI\",\"ort\":\"OgYJGoTqGf\",\"postleitzahl\":\"NwPWXepscdf\",\"stockwerk\":\"PdAUUMxbw\",\"strasse\":\"\",\"strasseZusatz\":\"yACrKFrMSxXdrE\",\"tuernummer\":\"IAaSgYefVK\"},\"zaehlpunktname\":\"UnT\",\"zaehlpunktnummer\":\"DYIOOcJwWYt\"}"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "401" : {
+            "description" : "Access Denied"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not found"
+          }
+        },
+        "security" : [ { } ]
+      }
+    },
+    "/zaehlpunkte/{zaehlpunkt}/messwerte" : {
+      "summary" : "",
+      "description" : "",
+      "get" : {
+        "summary" : "",
+        "description" : "",
+        "operationId" : "getZaehlpunktMesswerte",
+        "parameters" : [ {
+          "name" : "wertetyp",
+          "in" : "query",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "datumBis",
+          "in" : "query",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "datumVon",
+          "in" : "query",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "zaehlpunkt",
+          "in" : "path",
+          "description" : "",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "webProfileId",
+          "in" : "query",
+          "description" : "",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Successful",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/zaehlpunktezaehlpunktmesswerte_GET_response"
+                },
+                "example" : "{\"zaehlpunkt\":\"TM\",\"zaehlwerke\":[{\"einheit\":\"wNIKaR\",\"messwerte\":[{\"messwert\":630961152,\"qualitaet\":\"KKQmiWKWSHp\",\"zeitBis\":\"UAcRx\",\"zeitVon\":\"gKtKju\"}],\"obisCode\":\"hAWhjaPpL\"}]}"
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "401" : {
+            "description" : "Access Denied"
+          },
+          "500" : {
+            "description" : "Internal Server Error"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not found"
+          }
+        },
+        "security" : [ { } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "Geraet" : {
+        "required" : [ "equipmentnummer", "geraetenummer" ],
+        "type" : "object",
+        "properties" : {
+          "equipmentnummer" : {
+            "type" : "string"
+          },
+          "geraetenummer" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Messwert" : {
+        "required" : [ "messwert", "qualitaet", "zeitBis", "zeitVon" ],
+        "type" : "object",
+        "properties" : {
+          "messwert" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "qualitaet" : {
+            "type" : "string"
+          },
+          "zeitBis" : {
+            "type" : "string"
+          },
+          "zeitVon" : {
+            "type" : "string"
+          }
+        }
+      },
+      "zaehlpunktezaehlpunktmesswerte_GET_response" : {
+        "required" : [ "zaehlpunkt", "zaehlwerke" ],
+        "type" : "object",
+        "properties" : {
+          "zaehlpunkt" : {
+            "type" : "string"
+          },
+          "zaehlwerke" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ZaehlwerkMesswerte"
+            }
+          }
+        }
+      },
+      "ZaehlwerkMesswerte" : {
+        "required" : [ "einheit", "messwerte", "obisCode" ],
+        "type" : "object",
+        "properties" : {
+          "einheit" : {
+            "type" : "string"
+          },
+          "messwerte" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Messwert"
+            }
+          },
+          "obisCode" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Verbrauchsstelle" : {
+        "required" : [ "haus", "hausnummer1", "hausnummer2", "land", "ort", "postleitzahl", "stockwerk", "strasse", "strasseZusatz", "tuernummer" ],
+        "type" : "object",
+        "properties" : {
+          "haus" : {
+            "type" : "string"
+          },
+          "hausnummer1" : {
+            "type" : "string"
+          },
+          "hausnummer2" : {
+            "type" : "string"
+          },
+          "land" : {
+            "type" : "string"
+          },
+          "ort" : {
+            "type" : "string"
+          },
+          "postleitzahl" : {
+            "type" : "string"
+          },
+          "stockwerk" : {
+            "type" : "string"
+          },
+          "strasse" : {
+            "type" : "string"
+          },
+          "strasseZusatz" : {
+            "type" : "string"
+          },
+          "tuernummer" : {
+            "type" : "string"
+          }
+        }
+      },
+      "zaehlpunkte_GET_response" : {
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "$ref" : "#/components/schemas/Zaehlpunkt"
+          }
+        }
+      },
+      "ZaehlpunktMesswerte" : {
+        "required" : [ "zaehlpunkt", "zaehlwerke" ],
+        "type" : "object",
+        "properties" : {
+          "zaehlpunkt" : {
+            "type" : "string"
+          },
+          "zaehlwerke" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ZaehlwerkMesswerte"
+            }
+          }
+        }
+      },
+      "zaehlpunktemesswerte_GET_response" : {
+        "required" : [ "$rootArray" ],
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "$ref" : "#/components/schemas/ZaehlpunktMesswerte"
+          }
+        }
+      },
+      "Zaehlpunkt" : {
+        "required" : [ "anlage", "geraet", "idex", "verbrauchsstelle", "zaehlpunktname", "zaehlpunktnummer" ],
+        "type" : "object",
+        "properties" : {
+          "anlage" : {
+            "$ref" : "#/components/schemas/Anlage"
+          },
+          "geraet" : {
+            "$ref" : "#/components/schemas/Geraet"
+          },
+          "idex" : {
+            "$ref" : "#/components/schemas/Idex"
+          },
+          "verbrauchsstelle" : {
+            "$ref" : "#/components/schemas/Verbrauchsstelle"
+          },
+          "zaehlpunktname" : {
+            "type" : "string"
+          },
+          "zaehlpunktnummer" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Anlage" : {
+        "required" : [ "anlage", "sparte", "typ" ],
+        "type" : "object",
+        "properties" : {
+          "anlage" : {
+            "type" : "string"
+          },
+          "sparte" : {
+            "type" : "string"
+          },
+          "typ" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Idex" : {
+        "required" : [ "customerInterface", "displayLocked", "granularity" ],
+        "type" : "object",
+        "properties" : {
+          "customerInterface" : {
+            "type" : "string"
+          },
+          "displayLocked" : {
+            "type" : "boolean"
+          },
+          "granularity" : {
+            "type" : "string"
+          }
+        }
+      },
+      "zaehlpunktezaehlpunkt_GET_response" : {
+        "type" : "object",
+        "properties" : {
+          "anlage" : {
+            "$ref" : "#/components/schemas/Anlage"
+          },
+          "geraet" : {
+            "$ref" : "#/components/schemas/Geraet"
+          },
+          "idex" : {
+            "$ref" : "#/components/schemas/Idex"
+          },
+          "verbrauchsstelle" : {
+            "$ref" : "#/components/schemas/Verbrauchsstelle"
+          },
+          "zaehlpunktname" : {
+            "type" : "string"
+          },
+          "zaehlpunktnummer" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "x-Gateway-APIKey" : {
+        "type" : "apiKey",
+        "name" : "x-Gateway-APIKey",
+        "in" : "header"
+      },
+      "OAUTH2" : {
+        "type" : "oauth2",
+        "flows" : { }
+      }
+    }
+  }
+}

--- a/custom_components/wnsm/AsyncSmartmeter.py
+++ b/custom_components/wnsm/AsyncSmartmeter.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 from asyncio import Future
 from datetime import datetime
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .api import Smartmeter
 from .api.constants import ValueType
 from .const import ATTRS_METERREADINGS_CALL, ATTRS_BASEINFORMATION_CALL, ATTRS_CONSUMPTIONS_CALL, ATTRS_BEWEGUNGSDATEN, ATTRS_ZAEHLPUNKTE_CALL, ATTRS_HISTORIC_DATA, ATTRS_VERBRAUCH_CALL
 from .utils import translate_dict
@@ -13,8 +13,14 @@ from .utils import translate_dict
 _LOGGER = logging.getLogger(__name__)
 
 class AsyncSmartmeter:
+    """Async wrapper around any Smartmeter-compatible client.
 
-    def __init__(self, hass: HomeAssistant, smartmeter: Smartmeter = None):
+    Accepts both the legacy :class:`wnsm.api.client.Smartmeter` and the
+    :class:`wnsm.api.client_factory._OfficialSmartmeterShim` – callers
+    get to pick which one via :func:`wnsm.api.client_factory.make_client`.
+    """
+
+    def __init__(self, hass: HomeAssistant, smartmeter: Any = None):
         self.hass = hass
         self.smartmeter = smartmeter
         self.login_lock = asyncio.Lock()

--- a/custom_components/wnsm/api/__init__.py
+++ b/custom_components/wnsm/api/__init__.py
@@ -1,11 +1,24 @@
-"""Unofficial Python wrapper for the Wiener Netze Smart Meter private API."""
+"""Python wrappers for the Wiener Netze Smart Meter APIs.
+
+This package exposes two client implementations:
+
+``Smartmeter``
+    Legacy client talking to the private portal API. Relies on
+    HTML-scraping the Keycloak login flow.
+
+``OfficialSmartmeter``
+    Client for the public OAuth2 ``WN_SMART_METER_API`` gateway. Requires
+    a client_id / client_secret / x-Gateway-APIKey tuple issued by
+    Wiener Netze.
+"""
 from importlib.metadata import version
 
 from .client import Smartmeter
+from .official_client import OfficialSmartmeter
 
 try:
     __version__ = version(__name__)
 except Exception:  # pylint: disable=broad-except
     pass
 
-__all__ = ["Smartmeter"]
+__all__ = ["Smartmeter", "OfficialSmartmeter"]

--- a/custom_components/wnsm/api/adapter.py
+++ b/custom_components/wnsm/api/adapter.py
@@ -1,0 +1,284 @@
+"""Adapters that normalise official-API responses to the internal shape.
+
+The integration's sensors, statistics importer and config flow were all
+originally written against the private *portal* API. To keep those
+consumers untouched when we switch to :class:`OfficialSmartmeter`, this
+module translates the public ``WN_SMART_METER_API`` payloads into the
+dictionary layout that :mod:`wnsm.const` describes with
+``ATTRS_ZAEHLPUNKTE_CALL``, ``ATTRS_HISTORIC_DATA`` and
+``ATTRS_BEWEGUNGSDATEN``.
+
+The adapters are deliberately pure (no I/O, no global state) so they can
+be unit-tested in isolation and composed freely inside both the config
+flow and the async wrapper.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+from . import constants as const
+
+# Public type aliases keep the downstream call sites readable.
+OfficialZaehlpunkt = Dict[str, Any]
+OfficialMesswerte = Dict[str, Any]
+InternalZaehlpunkt = Dict[str, Any]
+InternalHistoric = Dict[str, Any]
+InternalBewegungsdaten = Dict[str, Any]
+
+# Role-code lookup used by the internal API. Matches
+# :class:`wnsm.api.constants.RoleType`. The official spec does not return
+# a role directly, so we derive it from the requested ``wertetyp`` and the
+# meter's ``anlage.typ`` (TAGSTROM → consuming, BEZUG → feeding).
+_ROLE_CONSUMING_DAILY = "V001"
+_ROLE_CONSUMING_QUARTER = "V002"
+_ROLE_FEEDING_DAILY = "E001"
+_ROLE_FEEDING_QUARTER = "E002"
+
+
+def zaehlpunkt_to_internal(
+    official: OfficialZaehlpunkt,
+    *,
+    customer_id: Optional[str] = None,
+) -> InternalZaehlpunkt:
+    """Translate a single official ``Zaehlpunkt`` to the internal shape.
+
+    Fields missing from the public API (``isDefault``, ``isActive``,
+    coordinates, …) are filled with sensible defaults so that the
+    existing ``translate_dict``/``ATTRS_ZAEHLPUNKTE_CALL`` pipeline keeps
+    working.
+
+    Parameters
+    ----------
+    official:
+        A payload as returned by ``GET /zaehlpunkte`` or
+        ``GET /zaehlpunkte/{zp}`` on the official gateway.
+    customer_id:
+        Optional ``geschaeftspartner`` value. The official API does not
+        expose the customer id, so callers that still need it must
+        forward it explicitly (e.g. from config flow input).
+    """
+    anlage = official.get("anlage") or {}
+    geraet = official.get("geraet") or {}
+    idex = official.get("idex") or {}
+    verbrauchsstelle = _normalise_verbrauchsstelle(
+        official.get("verbrauchsstelle") or {}
+    )
+
+    return {
+        "geschaeftspartner": customer_id,
+        "zaehlpunktnummer": official.get("zaehlpunktnummer"),
+        "customLabel": official.get("zaehlpunktname"),
+        "equipmentNumber": geraet.get("equipmentnummer"),
+        "geraetNumber": geraet.get("geraetenummer"),
+        "verbrauchsstelle": verbrauchsstelle,
+        "anlage": {
+            "typ": anlage.get("typ"),
+            "sparte": anlage.get("sparte"),
+            "anlage": anlage.get("anlage"),
+        },
+        # The public API does not surface these flags. Assume "active +
+        # default" because the API only returns meters the customer owns
+        # and opted into; inactive meters simply aren't returned.
+        "isDefault": True,
+        "isActive": True,
+        "isSmartMeterMarketReady": True,
+        "idexStatus": {
+            "granularity": {
+                "status": idex.get("granularity"),
+            },
+            "customerInterface": idex.get("customerInterface"),
+            "displayLocked": idex.get("displayLocked"),
+        },
+    }
+
+
+def zaehlpunkte_to_internal(
+    officials: Iterable[OfficialZaehlpunkt],
+    *,
+    customer_id: Optional[str] = None,
+) -> List[InternalZaehlpunkt]:
+    """Vectorised version of :func:`zaehlpunkt_to_internal`.
+
+    Returns a list with the same ordering as the input iterable so the
+    call site can re-use any positional cross-references.
+    """
+    return [
+        zaehlpunkt_to_internal(zp, customer_id=customer_id)
+        for zp in officials
+    ]
+
+
+def messwerte_to_historic_data(
+    official: OfficialMesswerte,
+) -> List[InternalHistoric]:
+    """Translate ``/zaehlpunkte/{zp}/messwerte`` to ``ATTRS_HISTORIC_DATA`` input.
+
+    The official payload groups readings by ``zaehlwerke``; each group
+    corresponds to one OBIS code / unit pair. We return one dict per
+    group with ``messwerte`` already converted to the lightweight shape
+    consumed by the sensors (``value``, ``timestamp``, ``zeitBis``,
+    ``quality``, ``isEstimated``).
+    """
+    zaehlwerke = official.get("zaehlwerke") or []
+    return [
+        {
+            "obisCode": zw.get("obisCode"),
+            "einheit": zw.get("einheit"),
+            "messwerte": [
+                _messwert_to_internal(mw) for mw in (zw.get("messwerte") or [])
+            ],
+        }
+        for zw in zaehlwerke
+    ]
+
+
+def messwerte_to_bewegungsdaten(
+    official: OfficialMesswerte,
+    *,
+    wertetyp: Union[const.Wertetyp, str],
+    anlagen_typ: Optional[str] = None,
+    customer_id: Optional[str] = None,
+    obis_code: Optional[str] = None,
+) -> InternalBewegungsdaten:
+    """Translate messwerte to the ``ATTRS_BEWEGUNGSDATEN`` input shape.
+
+    When the official response contains multiple ``zaehlwerke`` the first
+    one matching ``obis_code`` is used, or the first one overall if no
+    OBIS filter is given. This mirrors how the existing importer treats
+    the private API's single-series payload.
+    """
+    wertetyp_value = _coerce_wertetyp(wertetyp)
+    zaehlwerke = official.get("zaehlwerke") or []
+    zw = _pick_zaehlwerk(zaehlwerke, obis_code)
+    role = _derive_role(wertetyp_value, anlagen_typ)
+    granularitaet = _derive_granularitaet(wertetyp_value)
+
+    return {
+        "descriptor": {
+            "geschaeftspartnernummer": customer_id,
+            "zaehlpunktnummer": official.get("zaehlpunkt"),
+            "rolle": role,
+            "aggregat": "NONE",
+            "granularitaet": granularitaet,
+            "einheit": zw.get("einheit") if zw else None,
+            "obisCode": zw.get("obisCode") if zw else obis_code,
+        },
+        "values": [
+            _messwert_to_internal(mw)
+            for mw in (zw.get("messwerte") if zw else [])
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _normalise_verbrauchsstelle(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Align official field names with the legacy verbrauchsstelle keys.
+
+    The portal API used ``anlageHausnummer`` where the official API uses
+    ``hausnummer1``; ``translate_dict`` reads the legacy name, so we
+    emit both.
+    """
+    hausnummer = (raw.get("hausnummer1") or "").strip()
+    if raw.get("hausnummer2"):
+        hausnummer = f"{hausnummer}{raw['hausnummer2']}".strip()
+
+    return {
+        **raw,
+        "anlageHausnummer": hausnummer or None,
+        "hausnummer": hausnummer or None,
+        # Coordinates are not published by the public API.
+        "laengengrad": None,
+        "breitengrad": None,
+    }
+
+
+def _messwert_to_internal(mw: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten one ``Messwert`` to the lightweight shape consumed downstream.
+
+    Downstream consumers mix two naming conventions:
+
+    * The ``Importer`` reads ``wert``, ``zeitpunktVon`` and ``geschaetzt`` –
+      the German field names used by the legacy portal API.
+    * The ``WNSMSensor.get_meter_reading_from_historic_data`` helper reads
+      ``messwert``.
+    * New code we write in this project prefers the English aliases
+      (``value``, ``timestamp``, ``isEstimated``).
+
+    Emitting both keeps every consumer happy with a single adapter.
+    """
+    quality = mw.get("qualitaet")
+    value = mw.get("messwert")
+    zeit_von = mw.get("zeitVon")
+    zeit_bis = mw.get("zeitBis")
+    is_estimated = quality is not None and quality != "VAL"
+    return {
+        # English aliases (new code)
+        "value": value,
+        "timestamp": zeit_von,
+        "zeitVon": zeit_von,
+        "zeitBis": zeit_bis,
+        "quality": quality,
+        # "VAL" is the "validated" marker used by Wiener Netze; anything
+        # else (e.g. "ERS" for "Ersatzwert") is an estimate/replacement.
+        "isEstimated": is_estimated,
+        # Legacy portal-API keys consumed by the Importer / sensor
+        "wert": value,
+        "messwert": value,
+        "zeitpunktVon": zeit_von,
+        "zeitpunktBis": zeit_bis,
+        "geschaetzt": is_estimated,
+    }
+
+
+def _pick_zaehlwerk(
+    zaehlwerke: List[Dict[str, Any]],
+    obis_code: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not zaehlwerke:
+        return None
+    if obis_code is None:
+        return zaehlwerke[0]
+    for zw in zaehlwerke:
+        if zw.get("obisCode") == obis_code:
+            return zw
+    return zaehlwerke[0]
+
+
+def _coerce_wertetyp(value: Union[const.Wertetyp, str]) -> str:
+    if isinstance(value, const.Wertetyp):
+        return value.value
+    return const.Wertetyp.from_str(value).value
+
+
+def _derive_role(wertetyp: str, anlagen_typ: Optional[str]) -> str:
+    """Map ``wertetyp`` + ``anlage.typ`` to a legacy ``RoleType`` code."""
+    is_quarter = wertetyp == const.Wertetyp.QUARTER_HOUR.value
+    if anlagen_typ:
+        try:
+            category = const.AnlagenType.from_str(anlagen_typ)
+        except NotImplementedError:
+            category = const.AnlagenType.CONSUMING
+    else:
+        category = const.AnlagenType.CONSUMING
+
+    if category is const.AnlagenType.FEEDING:
+        return _ROLE_FEEDING_QUARTER if is_quarter else _ROLE_FEEDING_DAILY
+    return _ROLE_CONSUMING_QUARTER if is_quarter else _ROLE_CONSUMING_DAILY
+
+
+def _derive_granularitaet(wertetyp: str) -> str:
+    if wertetyp == const.Wertetyp.QUARTER_HOUR.value:
+        return "QH"
+    if wertetyp == const.Wertetyp.METER_READ.value:
+        return "MR"
+    return "D"
+
+
+__all__ = [
+    "zaehlpunkt_to_internal",
+    "zaehlpunkte_to_internal",
+    "messwerte_to_historic_data",
+    "messwerte_to_bewegungsdaten",
+]

--- a/custom_components/wnsm/api/client_factory.py
+++ b/custom_components/wnsm/api/client_factory.py
@@ -1,0 +1,290 @@
+"""Factory that returns the right Smartmeter implementation for a HA entry.
+
+The sensor and importer code paths in this integration are written
+against the legacy :class:`wnsm.api.client.Smartmeter` method surface
+(``login``/``zaehlpunkte``/``historical_data``/``bewegungsdaten``/…).
+When the user picks the official OAuth2 API in the config flow, we
+still want those call sites to Just Work. :func:`make_client` therefore
+returns either:
+
+* the legacy :class:`Smartmeter` – for entries that were created via the
+  username/password branch of the config flow, or
+* an :class:`_OfficialSmartmeterShim` – a thin adapter around
+  :class:`OfficialSmartmeter` that exposes the same method names and
+  translates the responses into the legacy shape via
+  :mod:`wnsm.api.adapter`.
+
+The shim intentionally does not try to emulate endpoints that do not
+exist on the public API. ``base_information``/``verbrauch``/
+``verbrauchRaw``/``consumptions`` all raise ``NotImplementedError`` with
+a clear message so users running the official API get a predictable
+failure instead of a mysterious ``AttributeError``.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from ..const import (
+    AUTH_METHOD_LEGACY,
+    AUTH_METHOD_OFFICIAL,
+    CONF_API_KEY,
+    CONF_AUTH_METHOD,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_CUSTOMER_ID,
+    CONF_SCOPE,
+    CONF_WEB_PROFILE_ID,
+)
+from . import adapter
+from .client import Smartmeter
+from .constants import ValueType, Wertetyp
+from .official_client import OfficialSmartmeter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# The sensor/importer speak in :class:`ValueType`; the official API
+# client speaks in :class:`Wertetyp`. Keep the mapping in one place.
+_VALUE_TYPE_TO_WERTETYP: Dict[ValueType, Wertetyp] = {
+    ValueType.METER_READ: Wertetyp.METER_READ,
+    ValueType.DAY: Wertetyp.DAY,
+    ValueType.QUARTER_HOUR: Wertetyp.QUARTER_HOUR,
+}
+
+
+_UNSUPPORTED_MSG = (
+    "The official WN_SMART_METER_API does not expose a '{method}' "
+    "equivalent. Use the legacy username/password integration if you "
+    "need that call."
+)
+
+
+def make_client(entry_data: Dict[str, Any]):
+    """Return a Smartmeter-compatible client for the given HA entry data.
+
+    The returned object always provides the legacy method names used by
+    :class:`wnsm.AsyncSmartmeter.AsyncSmartmeter`. The caller does not
+    need to know whether it is talking to the scraper or the official
+    API shim.
+    """
+    method = entry_data.get(CONF_AUTH_METHOD, AUTH_METHOD_LEGACY)
+    if method == AUTH_METHOD_OFFICIAL:
+        client = OfficialSmartmeter(
+            client_id=entry_data[CONF_CLIENT_ID],
+            client_secret=entry_data[CONF_CLIENT_SECRET],
+            api_key=entry_data[CONF_API_KEY],
+            web_profile_id=entry_data.get(CONF_WEB_PROFILE_ID) or None,
+            scope=entry_data.get(CONF_SCOPE) or None,
+        )
+        return _OfficialSmartmeterShim(
+            client=client,
+            customer_id=entry_data.get(CONF_CUSTOMER_ID) or None,
+        )
+
+    return Smartmeter(
+        entry_data[CONF_USERNAME],
+        entry_data[CONF_PASSWORD],
+    )
+
+
+@dataclass
+class _OfficialSmartmeterShim:
+    """Adapt :class:`OfficialSmartmeter` to the legacy Smartmeter surface.
+
+    Only the four methods the sensor and importer actually use are
+    implemented:
+
+    * :meth:`login`
+    * :meth:`zaehlpunkte` – wrapped into the legacy contract/zaehlpunkte
+      nesting expected by :meth:`AsyncSmartmeter.contracts2zaehlpunkte`.
+    * :meth:`historical_data` – returns the first matching zaehlwerk
+      flattened to a single dict, mirroring the legacy response shape.
+    * :meth:`bewegungsdaten` – returns the descriptor/values dict the
+      importer consumes.
+
+    Every other legacy method raises :class:`NotImplementedError`.
+    """
+
+    client: OfficialSmartmeter
+    customer_id: Optional[str] = None
+    _zp_cache: Optional[List[Dict[str, Any]]] = field(
+        default=None, init=False, repr=False
+    )
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+    def login(self) -> str:
+        return self.client.login()
+
+    def is_login_expired(self) -> bool:  # pragma: no cover - trivial
+        """Match the legacy Smartmeter surface.
+
+        :class:`OfficialSmartmeter` refreshes its token lazily inside
+        ``_get``; callers that poll ``is_login_expired`` always see a
+        valid token as long as ``login`` has been called at least once.
+        """
+        token = getattr(self.client, "_token", None)
+        return token is None or not token.is_valid()
+
+    # ------------------------------------------------------------------
+    # zaehlpunkte()
+    # ------------------------------------------------------------------
+    def zaehlpunkte(self) -> List[Dict[str, Any]]:
+        """Return the list of contracts with nested zaehlpunkte.
+
+        The legacy portal API groups meters by ``geschaeftspartner``
+        (contract). The official API returns a flat list, so we wrap
+        it in a single synthetic contract. The customer id (if known)
+        is propagated so :func:`AsyncSmartmeter.contracts2zaehlpunkte`
+        can annotate the children correctly.
+        """
+        raw = self.client.zaehlpunkte()
+        internal = adapter.zaehlpunkte_to_internal(
+            raw, customer_id=self.customer_id
+        )
+        self._zp_cache = internal
+        return [
+            {
+                "geschaeftspartner": self.customer_id,
+                "zaehlpunkte": internal,
+            }
+        ]
+
+    # ------------------------------------------------------------------
+    # historical_data()
+    # ------------------------------------------------------------------
+    def historical_data(
+        self,
+        zaehlpunktnummer: Optional[str] = None,
+        date_from: Optional[Union[datetime, str]] = None,
+        date_until: Optional[Union[datetime, str]] = None,
+        valuetype: ValueType = ValueType.METER_READ,
+    ) -> Dict[str, Any]:
+        """Fetch a historical series for a single meter.
+
+        Returns a single dict – not a list – so that downstream
+        ``translate_dict(response, ATTRS_HISTORIC_DATA)`` produces the
+        ``{obisCode, unitOfMeasurement, values}`` payload the sensor
+        expects.
+        """
+        if not zaehlpunktnummer:
+            raise ValueError(
+                "historical_data requires a zaehlpunktnummer when using the "
+                "official API"
+            )
+        wertetyp = self._coerce_wertetyp(valuetype)
+        raw = self.client.messwerte(
+            datum_von=date_from,
+            datum_bis=date_until,
+            wertetyp=wertetyp,
+            zaehlpunkt=zaehlpunktnummer,
+        )
+        payload = raw if isinstance(raw, dict) else {}
+        series = adapter.messwerte_to_historic_data(payload)
+        if series:
+            # Match the legacy portal behaviour of returning a single
+            # series per request. If several zaehlwerke are present the
+            # first one is the headline reading.
+            return series[0]
+        return {"obisCode": None, "einheit": None, "messwerte": []}
+
+    # ------------------------------------------------------------------
+    # bewegungsdaten()
+    # ------------------------------------------------------------------
+    def bewegungsdaten(
+        self,
+        zaehlpunktnummer: Optional[str] = None,
+        date_from: Optional[Union[datetime, str]] = None,
+        date_until: Optional[Union[datetime, str]] = None,
+        valuetype: ValueType = ValueType.QUARTER_HOUR,
+        aggregat: Optional[str] = None,  # noqa: ARG002 - kept for compat
+    ) -> Dict[str, Any]:
+        """Fetch meter movements for the importer.
+
+        The importer iterates ``values`` and expects ``wert``,
+        ``zeitpunktVon`` and ``geschaetzt`` keys – those are emitted by
+        ``adapter._messwert_to_internal`` alongside the English aliases.
+        """
+        if not zaehlpunktnummer:
+            raise ValueError(
+                "bewegungsdaten requires a zaehlpunktnummer when using the "
+                "official API"
+            )
+        wertetyp = self._coerce_wertetyp(valuetype)
+        raw = self.client.messwerte(
+            datum_von=date_from,
+            datum_bis=date_until,
+            wertetyp=wertetyp,
+            zaehlpunkt=zaehlpunktnummer,
+        )
+        payload = raw if isinstance(raw, dict) else {}
+        return adapter.messwerte_to_bewegungsdaten(
+            payload,
+            wertetyp=wertetyp,
+            anlagen_typ=self._anlagen_typ_for(zaehlpunktnummer),
+            customer_id=self.customer_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _anlagen_typ_for(self, zaehlpunkt: str) -> Optional[str]:
+        """Best-effort lookup of ``anlage.typ`` for role derivation.
+
+        Falls back to ``None`` (which the adapter treats as
+        "consuming") if the list cannot be pre-fetched. This keeps the
+        data path resilient when ``zaehlpunkte`` has not been called
+        yet – the first call will populate the cache and subsequent
+        requests get the correct role.
+        """
+        if self._zp_cache is None:
+            try:
+                self.zaehlpunkte()
+            except Exception as exc:  # pylint: disable=broad-except
+                _LOGGER.debug(
+                    "Could not pre-fetch zaehlpunkte while deriving role: %s",
+                    exc,
+                )
+                return None
+        for zp in self._zp_cache or []:
+            if zp.get("zaehlpunktnummer") == zaehlpunkt:
+                return (zp.get("anlage") or {}).get("typ")
+        return None
+
+    @staticmethod
+    def _coerce_wertetyp(value: Optional[ValueType]) -> Wertetyp:
+        if value is None:
+            return Wertetyp.QUARTER_HOUR
+        return _VALUE_TYPE_TO_WERTETYP.get(value, Wertetyp.QUARTER_HOUR)
+
+    # ------------------------------------------------------------------
+    # Unsupported legacy endpoints
+    # ------------------------------------------------------------------
+    def base_information(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError(
+            _UNSUPPORTED_MSG.format(method="base_information")
+        )
+
+    def verbrauch(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError(_UNSUPPORTED_MSG.format(method="verbrauch"))
+
+    def verbrauchRaw(  # noqa: N802 - matches legacy API name
+        self, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
+        raise NotImplementedError(
+            _UNSUPPORTED_MSG.format(method="verbrauchRaw")
+        )
+
+    def consumptions(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError(
+            _UNSUPPORTED_MSG.format(method="consumptions")
+        )
+
+
+__all__ = ["make_client", "_OfficialSmartmeterShim"]

--- a/custom_components/wnsm/api/constants.py
+++ b/custom_components/wnsm/api/constants.py
@@ -101,3 +101,48 @@ def build_verbrauchs_args(**kwargs):
     }
     args.update(**kwargs)
     return args
+
+
+# ---------------------------------------------------------------------------
+# Official Wiener Netze Smart Meter API (WN_SMART_METER_API)
+# ---------------------------------------------------------------------------
+# This is the public, OAuth2-secured API that Wiener Netze documents at
+# https://api-portal.wienerstadtwerke.at. Unlike the "portal" endpoints above,
+# it does not require any HTML scraping: authentication is a standard
+# OAuth2 client_credentials exchange and requests carry both a Bearer access
+# token and the per-application x-Gateway-APIKey header.
+
+OFFICIAL_API_URL: str = "https://api.wstw.at/gateway/WN_SMART_METER_API/1.0"
+OFFICIAL_TOKEN_URL: str = (
+    "https://api.wstw.at/invoke/pub.apigateway.oauth2/getAccessToken"
+)
+OFFICIAL_AUTHORIZE_URL: str = (
+    "https://api.wstw.at/invoke/pub.apigateway.oauth2/authorize"
+)
+OFFICIAL_DEFAULT_SCOPE: str = "profile"
+# Wiener Netze issues tokens valid for this many seconds; refresh a little
+# earlier so concurrent calls never race a just-expired token.
+OFFICIAL_TOKEN_VALIDITY_SECONDS: int = 3600
+OFFICIAL_TOKEN_REFRESH_LEEWAY_SECONDS: int = 60
+# Date format expected by /zaehlpunkte/messwerte (ISO 8601 date, no time).
+OFFICIAL_API_DATE_FORMAT: str = "%Y-%m-%d"
+
+
+class Wertetyp(enum.Enum):
+    """Valid ``wertetyp`` query parameter values for the official API.
+
+    These match what the Wiener Netze gateway accepts on
+    ``GET /zaehlpunkte/messwerte`` and ``GET /zaehlpunkte/{zp}/messwerte``.
+    """
+
+    QUARTER_HOUR = "QUARTER_HOUR"  #: 15-minute interval values
+    DAY = "DAY"  #: Daily aggregated values
+    METER_READ = "METER_READ"  #: Meter readings ("Zählerstand")
+
+    @staticmethod
+    def from_str(label: str) -> "Wertetyp":
+        normalised = label.strip().upper()
+        for member in Wertetyp:
+            if member.value == normalised:
+                return member
+        raise ValueError(f"Unknown Wertetyp: {label!r}")

--- a/custom_components/wnsm/api/official_client.py
+++ b/custom_components/wnsm/api/official_client.py
@@ -1,0 +1,374 @@
+"""Client for the official Wiener Netze Smart Meter API (WN_SMART_METER_API).
+
+This module talks to the public, OAuth2-secured gateway documented at
+``https://api-portal.wienerstadtwerke.at``. The endpoints and schemas are
+defined by the ``WN_SMART_METER_API`` OpenAPI specification:
+
+- ``GET /zaehlpunkte``
+- ``GET /zaehlpunkte/{zaehlpunkt}``
+- ``GET /zaehlpunkte/messwerte``
+- ``GET /zaehlpunkte/{zaehlpunkt}/messwerte``
+
+Unlike :mod:`wnsm.api.client`, no HTML scraping is required: a
+``client_credentials`` token exchange is enough to obtain a bearer token.
+Every request additionally carries the per-application ``x-Gateway-APIKey``
+header issued by Wiener Netze.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, List, Optional, Union
+from urllib.parse import urljoin
+
+import requests
+
+from . import constants as const
+from .errors import (
+    SmartmeterConnectionError,
+    SmartmeterLoginError,
+    SmartmeterQueryError,
+)
+
+logger = logging.getLogger(__name__)
+
+# Types accepted for the ``datumVon`` / ``datumBis`` parameters. ``str`` is
+# passed through unchanged to allow callers to supply vendor-specific
+# formats (e.g. datetimes including a time component) when needed.
+DateLike = Union[str, date, datetime]
+
+# The only grant type we use. The Wiener Netze gateway (webMethods) accepts
+# client_credentials on the ``getAccessToken`` endpoint when the application
+# has been configured with a client_id/secret pair in the portal.
+_GRANT_TYPE: str = "client_credentials"
+
+
+@dataclass
+class _Token:
+    """In-memory representation of a cached OAuth2 access token."""
+
+    access_token: str
+    expires_at: float  #: monotonic epoch seconds at which the token expires
+
+    def is_valid(self, leeway: int = const.OFFICIAL_TOKEN_REFRESH_LEEWAY_SECONDS) -> bool:
+        return bool(self.access_token) and (time.time() + leeway) < self.expires_at
+
+
+@dataclass
+class OfficialSmartmeter:
+    """Thin wrapper around the official Wiener Netze Smart Meter API.
+
+    The client is intentionally synchronous so that it can be used from the
+    Home Assistant executor (``hass.async_add_executor_job``) just like the
+    existing :class:`wnsm.api.client.Smartmeter`.
+
+    Parameters
+    ----------
+    client_id, client_secret:
+        OAuth2 credentials from the Wiener Netze API developer portal.
+    api_key:
+        The ``x-Gateway-APIKey`` value assigned to the application.
+    web_profile_id:
+        Optional default ``webProfileId`` passed as a query parameter to
+        every resource call. Leave ``None`` to omit it.
+    scope:
+        OAuth2 scope to request. Defaults to ``profile`` which is the scope
+        shown in the Wiener Netze portal.
+    base_url / token_url:
+        Overrides primarily useful in tests.
+    session:
+        Optional :class:`requests.Session` to reuse an external connection
+        pool. A fresh session is created if omitted.
+    """
+
+    client_id: str
+    client_secret: str
+    api_key: str
+    web_profile_id: Optional[str] = None
+    # Scope is intentionally optional and defaults to *None* – the
+    # reference wrapper at
+    # https://github.com/tschoerk/Wiener-Netze-Smart-Meter-API omits the
+    # scope field entirely, and issue #276 in this repo shows that the
+    # gateway rejects ``scope=profile`` for apps that were not explicitly
+    # provisioned with it ("The supplied scope (profile) is not
+    # associated with the client"). Users whose apps *do* require a
+    # scope can still set it via the config flow.
+    scope: Optional[str] = None
+    base_url: str = const.OFFICIAL_API_URL
+    token_url: str = const.OFFICIAL_TOKEN_URL
+    timeout: float = 30.0
+    session: requests.Session = field(default_factory=requests.Session)
+    _token: Optional[_Token] = field(default=None, init=False, repr=False)
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+    def login(self) -> str:
+        """Obtain an access token via the client_credentials grant.
+
+        Returns the raw bearer token. Raises :class:`SmartmeterLoginError`
+        on any non-2xx response or malformed payload.
+        """
+        data: Dict[str, str] = {
+            "grant_type": _GRANT_TYPE,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        if self.scope:
+            data["scope"] = self.scope
+
+        try:
+            response = self.session.post(
+                self.token_url,
+                data=data,
+                headers={
+                    "Accept": "application/json",
+                    # ``requests`` sets this implicitly when ``data`` is
+                    # a dict, but the Wiener Netze gateway is strict –
+                    # set it explicitly so intermediate proxies cannot
+                    # strip or rewrite the content type.
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise SmartmeterConnectionError(
+                f"Could not reach token endpoint: {exc}"
+            ) from exc
+
+        if response.status_code != 200:
+            raise SmartmeterLoginError(
+                "OAuth2 token request failed",
+                code=response.status_code,
+                error_response=response.text,
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise SmartmeterLoginError(
+                f"OAuth2 token response was not valid JSON: {exc}",
+                error_response=response.text,
+            ) from exc
+
+        access_token = payload.get("access_token")
+        if not access_token:
+            raise SmartmeterLoginError(
+                "OAuth2 token response did not contain an access_token",
+                error_response=response.text,
+            )
+
+        # ``expires_in`` is expressed in seconds according to RFC 6749 and
+        # webMethods honours that. Fall back to the documented default if
+        # the server omits it.
+        expires_in = int(
+            payload.get("expires_in") or const.OFFICIAL_TOKEN_VALIDITY_SECONDS
+        )
+        self._token = _Token(
+            access_token=access_token,
+            expires_at=time.time() + expires_in,
+        )
+        logger.debug(
+            "Obtained official API token, expires in %ss (scope=%s)",
+            expires_in,
+            payload.get("scope", self.scope),
+        )
+        return access_token
+
+    def _ensure_token(self) -> str:
+        """Return a valid access token, refreshing it transparently."""
+        if self._token is None or not self._token.is_valid():
+            self.login()
+        assert self._token is not None  # for type checkers
+        return self._token.access_token
+
+    # ------------------------------------------------------------------
+    # Low-level request plumbing
+    # ------------------------------------------------------------------
+    def _get(
+        self,
+        path: str,
+        *,
+        query: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """GET ``path`` on the official API, returning the decoded JSON."""
+        token = self._ensure_token()
+
+        # ``urljoin`` only concatenates correctly when the base ends with a
+        # trailing slash, so we normalise explicitly rather than relying on
+        # the caller to get the slashes right.
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+
+        params: Dict[str, Any] = {}
+        if self.web_profile_id:
+            params["webProfileId"] = self.web_profile_id
+        if query:
+            # Callers win over the default profile id if they pass one.
+            params.update({k: v for k, v in query.items() if v is not None})
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "x-Gateway-APIKey": self.api_key,
+            "Accept": "application/json",
+        }
+
+        try:
+            response = self.session.get(
+                url,
+                params=params,
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise SmartmeterConnectionError(
+                f"Failed to call {url}: {exc}"
+            ) from exc
+
+        if response.status_code == 401:
+            # Token might have been revoked out-of-band. Force a refresh
+            # once and retry; any further 401 is a genuine auth error.
+            logger.info("Official API returned 401, refreshing token and retrying")
+            self._token = None
+            token = self._ensure_token()
+            headers["Authorization"] = f"Bearer {token}"
+            try:
+                response = self.session.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+            except requests.RequestException as exc:
+                raise SmartmeterConnectionError(
+                    f"Failed to retry {url}: {exc}"
+                ) from exc
+
+        if response.status_code != 200:
+            raise SmartmeterQueryError(
+                f"Unexpected status {response.status_code} from {url}",
+                code=response.status_code,
+                error_response=response.text,
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise SmartmeterQueryError(
+                f"Response from {url} was not valid JSON: {exc}",
+                error_response=response.text,
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Endpoints
+    # ------------------------------------------------------------------
+    def zaehlpunkte(
+        self,
+        *,
+        zaehlpunkt: Optional[str] = None,
+        result_type: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """``GET /zaehlpunkte`` – list all meters for the authenticated customer.
+
+        The OpenAPI spec models the response as ``{"items": Zaehlpunkt}``
+        but in practice the gateway returns a JSON array of
+        :class:`Zaehlpunkt` objects. We accept both and always return a
+        plain list to simplify downstream consumers.
+        """
+        query: Dict[str, Any] = {}
+        if zaehlpunkt:
+            query["zaehlpunkt"] = zaehlpunkt
+        if result_type:
+            query["resultType"] = result_type
+
+        raw = self._get("zaehlpunkte", query=query)
+        return _as_list(raw)
+
+    def zaehlpunkt(self, zaehlpunkt: str) -> Dict[str, Any]:
+        """``GET /zaehlpunkte/{zaehlpunkt}`` – details for a single meter."""
+        if not zaehlpunkt:
+            raise ValueError("zaehlpunkt must be a non-empty string")
+        return self._get(f"zaehlpunkte/{zaehlpunkt}")
+
+    def messwerte(
+        self,
+        datum_von: DateLike,
+        datum_bis: DateLike,
+        wertetyp: Union[const.Wertetyp, str],
+        *,
+        zaehlpunkt: Optional[str] = None,
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """Fetch measurement values.
+
+        Calls ``GET /zaehlpunkte/{zaehlpunkt}/messwerte`` when a specific
+        meter is supplied, otherwise the bulk ``GET /zaehlpunkte/messwerte``
+        endpoint. The ``datumVon`` / ``datumBis`` parameters are formatted as
+        ``YYYY-MM-DD`` when a date/datetime is passed; plain strings are
+        forwarded unchanged so callers can opt into a different format.
+        """
+        query: Dict[str, Any] = {
+            "datumVon": _format_date(datum_von),
+            "datumBis": _format_date(datum_bis),
+            "wertetyp": _coerce_wertetyp(wertetyp),
+        }
+
+        if zaehlpunkt:
+            return self._get(
+                f"zaehlpunkte/{zaehlpunkt}/messwerte",
+                query=query,
+            )
+
+        raw = self._get("zaehlpunkte/messwerte", query=query)
+        # The bulk endpoint returns either ``{"items": ...}`` or a raw
+        # array; normalise to a list for the caller.
+        return _as_list(raw)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _format_date(value: DateLike) -> str:
+    """Format a date/datetime/string as ``YYYY-MM-DD``.
+
+    Strings are returned unchanged to keep the door open for callers who
+    need to supply an ISO 8601 datetime.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.date().strftime(const.OFFICIAL_API_DATE_FORMAT)
+    if isinstance(value, date):
+        return value.strftime(const.OFFICIAL_API_DATE_FORMAT)
+    raise TypeError(
+        f"datumVon/datumBis must be str, date or datetime, got {type(value).__name__}"
+    )
+
+
+def _coerce_wertetyp(value: Union[const.Wertetyp, str]) -> str:
+    if isinstance(value, const.Wertetyp):
+        return value.value
+    return const.Wertetyp.from_str(value).value
+
+
+def _as_list(raw: Any) -> List[Dict[str, Any]]:
+    """Normalise the API's ``items`` / bare-array duality to a list."""
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        items = raw.get("items")
+        if items is None:
+            # Some variants wrap a single object instead of an array.
+            return [raw]
+        if isinstance(items, list):
+            return items
+        return [items]
+    # Anything else is unexpected but we refuse to silently discard it.
+    raise SmartmeterQueryError(
+        f"Unexpected payload type from official API: {type(raw).__name__}"
+    )
+
+
+__all__ = ["OfficialSmartmeter"]

--- a/custom_components/wnsm/config_flow.py
+++ b/custom_components/wnsm/config_flow.py
@@ -9,63 +9,175 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-from .api import Smartmeter
-from .const import ATTRS_ZAEHLPUNKTE_CALL, DOMAIN, CONF_ZAEHLPUNKTE
+from .api import OfficialSmartmeter, Smartmeter
+from .api import adapter as official_adapter
+from .const import (
+    ATTRS_ZAEHLPUNKTE_CALL,
+    AUTH_METHOD_LEGACY,
+    AUTH_METHOD_OFFICIAL,
+    CONF_API_KEY,
+    CONF_AUTH_METHOD,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_CUSTOMER_ID,
+    CONF_SCOPE,
+    CONF_WEB_PROFILE_ID,
+    CONF_ZAEHLPUNKTE,
+    DOMAIN,
+)
 from .utils import translate_dict
 
 _LOGGER = logging.getLogger(__name__)
 
-AUTH_SCHEMA = vol.Schema(
+LEGACY_AUTH_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
+)
+
+OFFICIAL_AUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CLIENT_ID): cv.string,
+        vol.Required(CONF_CLIENT_SECRET): cv.string,
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_WEB_PROFILE_ID): cv.string,
+        vol.Optional(CONF_CUSTOMER_ID): cv.string,
+        # Optional scope — omit unless Wiener Netze explicitly told you
+        # the app was provisioned with one. See issue #276.
+        vol.Optional(CONF_SCOPE): cv.string,
+    }
 )
 
 
 class WienerNetzeSmartMeterCustomConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Wiener Netze Smartmeter config flow"""
+    """Wiener Netze Smartmeter config flow.
+
+    The first step is a menu that lets the user choose between the legacy
+    username/password scraper and the new OAuth2-based official API. Each
+    branch collects the appropriate credentials, validates them by
+    performing one live ``zaehlpunkte`` call, then creates the entry.
+    """
+
+    VERSION = 1
 
     data: Optional[dict[str, Any]]
 
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
     async def validate_auth(self, username: str, password: str) -> list[dict]:
-        """
-        Validates credentials for smartmeter.
-        Raises a ValueError if the auth credentials are invalid.
-        """
+        """Validate legacy credentials and return the list of zaehlpunkte."""
         smartmeter = Smartmeter(username, password)
         await self.hass.async_add_executor_job(smartmeter.login)
         contracts = await self.hass.async_add_executor_job(smartmeter.zaehlpunkte)
-        zaehlpunkte=[]
+        zaehlpunkte = []
         if contracts is not None and isinstance(contracts, list) and len(contracts) > 0:
             for contract in contracts:
                 if "zaehlpunkte" in contract:
                     zaehlpunkte.extend(contract["zaehlpunkte"])
         return zaehlpunkte
 
+    async def validate_official_auth(
+        self,
+        client_id: str,
+        client_secret: str,
+        api_key: str,
+        web_profile_id: Optional[str],
+        customer_id: Optional[str],
+        scope: Optional[str] = None,
+    ) -> list[dict]:
+        """Validate official API credentials and return legacy-shaped zaehlpunkte."""
+        client = OfficialSmartmeter(
+            client_id=client_id,
+            client_secret=client_secret,
+            api_key=api_key,
+            web_profile_id=web_profile_id or None,
+            scope=scope or None,
+        )
+        await self.hass.async_add_executor_job(client.login)
+        raw = await self.hass.async_add_executor_job(client.zaehlpunkte)
+        return official_adapter.zaehlpunkte_to_internal(
+            raw,
+            customer_id=customer_id or None,
+        )
 
+    # ------------------------------------------------------------------
+    # Steps
+    # ------------------------------------------------------------------
     async def async_step_user(self, user_input: Optional[dict[str, Any]] = None):
-        """Invoked when a user initiates a flow via the user interface."""
+        """Top-level entry point — show the auth-method picker."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options={
+                AUTH_METHOD_OFFICIAL: "Official API (OAuth2)",
+                AUTH_METHOD_LEGACY: "Username & Password (legacy)",
+            },
+        )
+
+    async def async_step_legacy(
+        self, user_input: Optional[dict[str, Any]] = None
+    ):
+        """Username/password branch (legacy scraper)."""
         errors: dict[str, str] = {}
-        zps = []
+        zps: list[dict] = []
         if user_input is not None:
             try:
                 zps = await self.validate_auth(
                     user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
                 )
             except Exception as exception:  # pylint: disable=broad-except
-                _LOGGER.error("Error validating Wiener Netze auth")
+                _LOGGER.error("Error validating Wiener Netze legacy auth")
                 _LOGGER.exception(exception)
                 errors["base"] = "auth"
             if not errors:
-                # Input is valid, set data
-                self.data = user_input
+                self.data = dict(user_input)
+                self.data[CONF_AUTH_METHOD] = AUTH_METHOD_LEGACY
                 self.data[CONF_ZAEHLPUNKTE] = [
-                    translate_dict(zp, ATTRS_ZAEHLPUNKTE_CALL) for zp in zps
-                    if zp["isActive"] # only create active zaehlpunkte, as inactive ones can appear in old contracts
+                    translate_dict(zp, ATTRS_ZAEHLPUNKTE_CALL)
+                    for zp in zps
+                    # only create active zaehlpunkte, as inactive ones
+                    # can appear in old contracts
+                    if zp.get("isActive")
                 ]
-                # User is done authenticating, create entry
                 return self.async_create_entry(
                     title="Wiener Netze Smartmeter", data=self.data
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=AUTH_SCHEMA, errors=errors
+            step_id="legacy", data_schema=LEGACY_AUTH_SCHEMA, errors=errors
+        )
+
+    async def async_step_official(
+        self, user_input: Optional[dict[str, Any]] = None
+    ):
+        """Official OAuth2 API branch."""
+        errors: dict[str, str] = {}
+        zps: list[dict] = []
+        if user_input is not None:
+            try:
+                zps = await self.validate_official_auth(
+                    client_id=user_input[CONF_CLIENT_ID],
+                    client_secret=user_input[CONF_CLIENT_SECRET],
+                    api_key=user_input[CONF_API_KEY],
+                    web_profile_id=user_input.get(CONF_WEB_PROFILE_ID),
+                    customer_id=user_input.get(CONF_CUSTOMER_ID),
+                    scope=user_input.get(CONF_SCOPE),
+                )
+            except Exception as exception:  # pylint: disable=broad-except
+                _LOGGER.error("Error validating Wiener Netze official API auth")
+                _LOGGER.exception(exception)
+                errors["base"] = "auth"
+            if not errors:
+                self.data = dict(user_input)
+                self.data[CONF_AUTH_METHOD] = AUTH_METHOD_OFFICIAL
+                self.data[CONF_ZAEHLPUNKTE] = [
+                    translate_dict(zp, ATTRS_ZAEHLPUNKTE_CALL)
+                    for zp in zps
+                    if zp.get("isActive", True)
+                ]
+                return self.async_create_entry(
+                    title="Wiener Netze Smartmeter (Official API)",
+                    data=self.data,
+                )
+
+        return self.async_show_form(
+            step_id="official", data_schema=OFFICIAL_AUTH_SCHEMA, errors=errors
         )

--- a/custom_components/wnsm/const.py
+++ b/custom_components/wnsm/const.py
@@ -5,6 +5,24 @@ DOMAIN = "wnsm"
 
 CONF_ZAEHLPUNKTE = "zaehlpunkte"
 
+# --- Auth method selection (config flow) -----------------------------------
+CONF_AUTH_METHOD = "auth_method"
+
+AUTH_METHOD_LEGACY = "legacy"          #: Username/password scraper
+AUTH_METHOD_OFFICIAL = "official"      #: OAuth2 + x-Gateway-APIKey
+
+# --- Credentials for the official WN_SMART_METER_API -----------------------
+CONF_CLIENT_ID = "client_id"
+CONF_CLIENT_SECRET = "client_secret"
+CONF_API_KEY = "api_key"
+CONF_WEB_PROFILE_ID = "web_profile_id"
+CONF_CUSTOMER_ID = "customer_id"
+# Optional OAuth2 ``scope`` value. Most apps registered in the Wiener
+# Stadtwerke developer portal are NOT provisioned with a scope, so the
+# gateway rejects ``scope=profile`` with "scope not associated with the
+# client" (see repository issue #276). Leave empty to omit the field.
+CONF_SCOPE = "scope"
+
 ATTRS_ZAEHLPUNKT_CALL = [
     ("zaehlpunktnummer", "zaehlpunktnummer"),
     ("customLabel", "label"),

--- a/custom_components/wnsm/sensor.py
+++ b/custom_components/wnsm/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.typing import (
     ConfigType,
     DiscoveryInfoType,
 )
-from .const import CONF_ZAEHLPUNKTE
+from .const import AUTH_METHOD_LEGACY, CONF_AUTH_METHOD, CONF_ZAEHLPUNKTE
 from .wnsm_sensor import WNSMSensor
 # Time between updating data from Wiener Netze
 SCAN_INTERVAL = timedelta(minutes=60 * 6)
@@ -42,7 +42,7 @@ async def async_setup_entry(
     """Setup sensors from a config entry created in the integrations UI."""
     config = hass.data[DOMAIN][config_entry.entry_id]
     wnsm_sensors = [
-        WNSMSensor(config[CONF_USERNAME], config[CONF_PASSWORD], zp["zaehlpunktnummer"])
+        WNSMSensor(config, zp["zaehlpunktnummer"])
         for zp in config[CONF_ZAEHLPUNKTE]
     ]
     async_add_entities(wnsm_sensors, update_before_add=True)
@@ -57,5 +57,11 @@ async def async_setup_platform(
     ] = None,  # pylint: disable=unused-argument
 ) -> None:
     """Set up the sensor platform by adding it into configuration.yaml"""
-    wnsm_sensor = WNSMSensor(config[CONF_USERNAME], config[CONF_PASSWORD], config[CONF_DEVICE_ID])
+    # YAML configuration only supports the legacy username/password path.
+    legacy_entry = {
+        CONF_AUTH_METHOD: AUTH_METHOD_LEGACY,
+        CONF_USERNAME: config[CONF_USERNAME],
+        CONF_PASSWORD: config[CONF_PASSWORD],
+    }
+    wnsm_sensor = WNSMSensor(legacy_entry, config[CONF_DEVICE_ID])
     async_add_entities([wnsm_sensor], update_before_add=True)

--- a/custom_components/wnsm/translations/en.json
+++ b/custom_components/wnsm/translations/en.json
@@ -1,18 +1,38 @@
 {
   "config": {
     "error": {
-      "auth": "Username/password invalid",
+      "auth": "Authentication failed — please double-check your credentials.",
       "connection_error": "Unable to connect"
     },
     "flow_title": "Wiener Netze Smartmeter",
     "step": {
       "user": {
-        "title": "Wiener Netze Smartmeter Authentication",
-        "description": "Enter your Wiener Netze Smartmeter credentials",
+        "title": "Wiener Netze Smartmeter",
+        "description": "Choose how you want to connect to Wiener Netze. The official API is the recommended path if you have obtained an application (API key + OAuth2 client) from https://api-portal.wienerstadtwerke.at.",
+        "menu_options": {
+          "official": "Official API (OAuth2 + API key)",
+          "legacy": "Username & Password (legacy)"
+        }
+      },
+      "legacy": {
+        "title": "Wiener Netze — Username & Password",
+        "description": "Enter your Wiener Netze Smartmeter portal credentials. This path scrapes the web portal and may break when Wiener Netze changes its login page.",
         "data": {
           "username": "Username",
           "password": "Password"
-        }        
+        }
+      },
+      "official": {
+        "title": "Wiener Netze — Official API",
+        "description": "Enter the credentials of your Wiener Netze API application. The Client ID, Client Secret and API key are visible in the application detail page of the Wiener Stadtwerke API portal. Before this works you must also ask Wiener Netze (via email) to link your smart meter account to the application. 'webProfileId', 'customerId' and 'scope' are optional — leave 'scope' empty unless Wiener Netze explicitly told you the app was provisioned with one (sending 'profile' otherwise returns 'scope not associated with the client').",
+        "data": {
+          "client_id": "OAuth2 Client ID",
+          "client_secret": "OAuth2 Client Secret",
+          "api_key": "x-Gateway-APIKey",
+          "web_profile_id": "Web profile ID (optional)",
+          "customer_id": "Customer / Geschäftspartner number (optional)",
+          "scope": "OAuth2 scope (optional, leave empty by default)"
+        }
       }
     }
   }

--- a/custom_components/wnsm/wnsm_sensor.py
+++ b/custom_components/wnsm/wnsm_sensor.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -12,7 +12,7 @@ from homeassistant.const import UnitOfEnergy
 from homeassistant.util import slugify
 
 from .AsyncSmartmeter import AsyncSmartmeter
-from .api import Smartmeter
+from .api.client_factory import make_client
 from .api.constants import ValueType
 from .importer import Importer
 from .utils import before, today
@@ -29,10 +29,12 @@ class WNSMSensor(SensorEntity):
     def _icon(self) -> str:
         return "mdi:flash"
 
-    def __init__(self, username: str, password: str, zaehlpunkt: str) -> None:
+    def __init__(self, entry_data: Dict[str, Any], zaehlpunkt: str) -> None:
         super().__init__()
-        self.username = username
-        self.password = password
+        # Store the full HA entry payload so ``make_client`` can pick the
+        # right backend (legacy scraper vs. OAuth2 official API) on every
+        # update without the sensor having to care which one is active.
+        self._entry_data = entry_data
         self.zaehlpunkt = zaehlpunkt
 
         self._attr_native_value: int | float | None = 0
@@ -83,7 +85,7 @@ class WNSMSensor(SensorEntity):
         update sensor
         """
         try:
-            smartmeter = Smartmeter(username=self.username, password=self.password)
+            smartmeter = make_client(self._entry_data)
             async_smartmeter = AsyncSmartmeter(self.hass, smartmeter)
             await async_smartmeter.login()
             zaehlpunkt_response = await async_smartmeter.get_zaehlpunkt(self.zaehlpunkt)

--- a/tests/test_official_client.py
+++ b/tests/test_official_client.py
@@ -18,7 +18,6 @@ of pure API-client code.
 from __future__ import annotations
 
 import importlib.util
-import os
 import sys
 import types
 from datetime import date, datetime, timedelta

--- a/tests/test_official_client.py
+++ b/tests/test_official_client.py
@@ -1,0 +1,951 @@
+"""Unit tests for the official Wiener Netze Smart Meter API client.
+
+These tests exercise :class:`wnsm.api.official_client.OfficialSmartmeter`
+against a ``requests_mock`` backend, so no real Wiener Netze credentials
+are required. They focus on the four aspects that are easy to get wrong:
+
+* OAuth2 client_credentials token handling and caching
+* Header wiring (``Authorization`` + ``x-Gateway-APIKey``)
+* Query parameter assembly for each endpoint
+* Normalisation of ``{"items": ...}`` vs bare-array responses
+
+The file intentionally sits at ``tests/`` (not ``tests/it/``) so that
+collection does not execute ``tests/it/__init__.py``, which eager-imports
+``homeassistant`` – a dependency we don't want to require for unit tests
+of pure API-client code.
+"""
+# pylint: disable=redefined-outer-name,wrong-import-position
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Bootstrap: load the three API submodules directly from their files so we
+# don't trigger ``wnsm/__init__.py`` (which imports ``homeassistant``).
+#
+# When ``homeassistant`` *is* installed (CI or a dev env that installed
+# ``tests/requirements.txt``) the stub below is harmless – it just shadows
+# the real package modules with loader-less placeholders that redirect
+# submodule lookups to the real files on disk. Either way, ``from
+# wnsm.api... import ...`` in the test body Just Works.
+# ---------------------------------------------------------------------------
+_WNSM_ROOT: Path = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "wnsm"
+)
+
+
+def _install_stub_package(name: str, path: Path) -> types.ModuleType:
+    """Register an empty namespace package so submodule imports resolve."""
+    if name in sys.modules:
+        return sys.modules[name]
+    module = types.ModuleType(name)
+    module.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[name] = module
+    return module
+
+
+def _load_file(fullname: str, path: Path) -> types.ModuleType:
+    """Load a .py file as ``fullname`` without going through ``importlib`` caches."""
+    if fullname in sys.modules:
+        return sys.modules[fullname]
+    spec = importlib.util.spec_from_file_location(fullname, path)
+    assert spec is not None and spec.loader is not None, f"no loader for {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[fullname] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_stub_package("wnsm", _WNSM_ROOT)
+_install_stub_package("wnsm.api", _WNSM_ROOT / "api")
+_load_file("wnsm.api.constants", _WNSM_ROOT / "api" / "constants.py")
+_load_file("wnsm.api.errors", _WNSM_ROOT / "api" / "errors.py")
+_load_file("wnsm.api.official_client", _WNSM_ROOT / "api" / "official_client.py")
+_load_file("wnsm.api.adapter", _WNSM_ROOT / "api" / "adapter.py")
+
+
+# ---------------------------------------------------------------------------
+# Extra bootstrap for :mod:`wnsm.api.client_factory`. The factory lives
+# above the homeassistant boundary (it imports ``homeassistant.const`` for
+# the legacy username/password keys and transitively loads the scraper
+# client). We stub all three out so the pure-Python shim code is testable
+# without installing ``homeassistant``, ``lxml`` or ``python-dateutil``.
+# ---------------------------------------------------------------------------
+def _install_stub_module(name: str, **attrs: Any) -> types.ModuleType:
+    """Create (or extend) a fake module with the given attributes."""
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    return module
+
+
+if "homeassistant" not in sys.modules:
+    _install_stub_module("homeassistant")
+_install_stub_module(
+    "homeassistant.const",
+    CONF_USERNAME="username",
+    CONF_PASSWORD="password",
+)
+
+
+class _StubSmartmeter:
+    """Placeholder for the legacy scraper – the factory only needs the class
+    object to switch on, the test never instantiates it."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+_install_stub_module("wnsm.api.client", Smartmeter=_StubSmartmeter)
+
+# Load wnsm.const + client_factory from the real files now that all
+# cross-package imports resolve against the stubs above.
+_load_file("wnsm.const", _WNSM_ROOT / "const.py")
+_load_file(
+    "wnsm.api.client_factory", _WNSM_ROOT / "api" / "client_factory.py"
+)
+
+import pytest  # noqa: E402
+from requests_mock import Mocker  # noqa: E402
+
+from wnsm.api import constants as const  # noqa: E402
+from wnsm.api.errors import (  # noqa: E402
+    SmartmeterConnectionError,
+    SmartmeterLoginError,
+    SmartmeterQueryError,
+)
+from wnsm.api.official_client import OfficialSmartmeter  # noqa: E402
+
+CLIENT_ID = "cid-test"
+CLIENT_SECRET = "secret-test"  # noqa: S105 - test fixture
+API_KEY = "gateway-key-test"
+ACCESS_TOKEN = "token-abc123"
+
+
+def _mock_token(
+    requests_mock: Mocker,
+    *,
+    token: str = ACCESS_TOKEN,
+    expires_in: int = 3600,
+    status: int = 200,
+    body: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Register the OAuth2 token endpoint mock."""
+    payload: Dict[str, Any] = body if body is not None else {
+        "access_token": token,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+        "scope": "profile",
+    }
+    requests_mock.post(
+        const.OFFICIAL_TOKEN_URL, json=payload, status_code=status
+    )
+
+
+def _make_client(**overrides: Any) -> OfficialSmartmeter:
+    kwargs: Dict[str, Any] = {
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "api_key": API_KEY,
+    }
+    kwargs.update(overrides)
+    return OfficialSmartmeter(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# login()
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("requests_mock")
+def test_login_success_stores_token(requests_mock: Mocker):
+    _mock_token(requests_mock)
+
+    client = _make_client()
+    token = client.login()
+
+    assert token == ACCESS_TOKEN
+    history = requests_mock.request_history
+    assert len(history) == 1
+    assert history[0].url == const.OFFICIAL_TOKEN_URL
+    body = history[0].text
+    assert "grant_type=client_credentials" in body
+    assert f"client_id={CLIENT_ID}" in body
+    assert "client_secret=secret-test" in body
+    # Scope is intentionally omitted by default – see issue #276 and the
+    # reference wrapper at tschoerk/Wiener-Netze-Smart-Meter-API. Sending
+    # ``scope=profile`` causes "scope not associated with the client"
+    # errors on apps that weren't explicitly provisioned with it.
+    assert "scope=" not in body
+    # Gateway is strict about Content-Type; make sure we pin it.
+    assert history[0].headers.get("Content-Type") == (
+        "application/x-www-form-urlencoded"
+    )
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_login_sends_scope_only_when_explicitly_configured(requests_mock: Mocker):
+    _mock_token(requests_mock)
+
+    _make_client(scope="profile").login()
+
+    body = requests_mock.request_history[0].text
+    assert "scope=profile" in body
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_login_error_raises_login_error(requests_mock: Mocker):
+    _mock_token(
+        requests_mock,
+        status=401,
+        body={"error": "invalid_client"},
+    )
+
+    with pytest.raises(SmartmeterLoginError) as exc_info:
+        _make_client().login()
+
+    assert exc_info.value.code == 401
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_login_missing_access_token_raises(requests_mock: Mocker):
+    _mock_token(requests_mock, body={"token_type": "Bearer"})
+
+    with pytest.raises(SmartmeterLoginError):
+        _make_client().login()
+
+
+def test_login_connection_error_raises_connection_error():
+    # Deliberately not using requests_mock: we want the underlying transport
+    # to actually fail so we can prove the exception gets wrapped.
+    client = _make_client(token_url="http://127.0.0.1:1/nope")
+    with pytest.raises(SmartmeterConnectionError):
+        client.login()
+
+
+# ---------------------------------------------------------------------------
+# zaehlpunkte()
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("requests_mock")
+def test_zaehlpunkte_sends_correct_headers_and_returns_list(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    sample = [
+        {
+            "zaehlpunktnummer": "AT0010000000000000001000000000001",
+            "zaehlpunktname": "Haushalt",
+            "anlage": {"anlage": "42", "sparte": "STROM", "typ": "TAGSTROM"},
+            "geraet": {"equipmentnummer": "E1", "geraetenummer": "G1"},
+            "idex": {
+                "customerInterface": "ENABLED",
+                "displayLocked": False,
+                "granularity": "QUARTER_HOUR",
+            },
+            "verbrauchsstelle": {
+                "haus": "",
+                "hausnummer1": "1",
+                "hausnummer2": "",
+                "land": "AT",
+                "ort": "Wien",
+                "postleitzahl": "1010",
+                "stockwerk": "",
+                "strasse": "Ringstr.",
+                "strasseZusatz": "",
+                "tuernummer": "",
+            },
+        }
+    ]
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte",
+        json=sample,
+    )
+
+    client = _make_client(web_profile_id="profile-1")
+    result = client.zaehlpunkte()
+
+    assert result == sample
+
+    call = requests_mock.request_history[-1]
+    assert call.headers["Authorization"] == f"Bearer {ACCESS_TOKEN}"
+    assert call.headers["x-Gateway-APIKey"] == API_KEY
+    assert call.qs.get("webprofileid") == ["profile-1"]
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_zaehlpunkte_unwraps_items_envelope(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte",
+        json={"items": [{"zaehlpunktnummer": "AT0001"}]},
+    )
+
+    result = _make_client().zaehlpunkte()
+
+    assert result == [{"zaehlpunktnummer": "AT0001"}]
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_zaehlpunkte_forwards_query_parameters(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte",
+        json=[],
+    )
+
+    _make_client().zaehlpunkte(zaehlpunkt="AT00XX", result_type="full")
+
+    call = requests_mock.request_history[-1]
+    # requests_mock lower-cases query-string keys *and* values in .qs
+    assert call.qs["zaehlpunkt"] == ["at00xx"]
+    assert call.qs["resulttype"] == ["full"]
+
+
+# ---------------------------------------------------------------------------
+# zaehlpunkt(zp)
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("requests_mock")
+def test_zaehlpunkt_detail(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    zp = "AT0010000000000000001000000000001"
+    payload = {"zaehlpunktnummer": zp, "zaehlpunktname": "Haushalt"}
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte/{zp}",
+        json=payload,
+    )
+
+    result = _make_client().zaehlpunkt(zp)
+
+    assert result == payload
+
+
+def test_zaehlpunkt_requires_id():
+    with pytest.raises(ValueError):
+        _make_client().zaehlpunkt("")
+
+
+# ---------------------------------------------------------------------------
+# messwerte()
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("requests_mock")
+def test_messwerte_single_zp_builds_expected_query(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    zp = "AT0010000000000000001000000000001"
+    payload = {
+        "zaehlpunkt": zp,
+        "zaehlwerke": [
+            {
+                "einheit": "WH",
+                "obisCode": "1-1:1.9.0",
+                "messwerte": [
+                    {
+                        "messwert": 123,
+                        "qualitaet": "VAL",
+                        "zeitVon": "2026-04-10T00:00:00Z",
+                        "zeitBis": "2026-04-10T00:15:00Z",
+                    }
+                ],
+            }
+        ],
+    }
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte/{zp}/messwerte",
+        json=payload,
+    )
+
+    result = _make_client().messwerte(
+        datum_von=date(2026, 4, 10),
+        datum_bis=date(2026, 4, 11),
+        wertetyp=const.Wertetyp.QUARTER_HOUR,
+        zaehlpunkt=zp,
+    )
+
+    assert result == payload
+    call = requests_mock.request_history[-1]
+    assert call.qs["datumvon"] == ["2026-04-10"]
+    assert call.qs["datumbis"] == ["2026-04-11"]
+    assert call.qs["wertetyp"] == ["quarter_hour"]
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_messwerte_bulk_unwraps_items(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte/messwerte",
+        json={"items": [{"zaehlpunkt": "AT01", "zaehlwerke": []}]},
+    )
+
+    result = _make_client().messwerte(
+        datum_von="2026-04-01",
+        datum_bis="2026-04-10",
+        wertetyp="DAY",
+    )
+
+    assert result == [{"zaehlpunkt": "AT01", "zaehlwerke": []}]
+
+
+def test_messwerte_rejects_unknown_wertetyp():
+    with pytest.raises(ValueError):
+        _make_client().messwerte(
+            datum_von="2026-04-01",
+            datum_bis="2026-04-02",
+            wertetyp="HOURLY",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token caching & refresh
+# ---------------------------------------------------------------------------
+@pytest.mark.usefixtures("requests_mock")
+def test_token_is_cached_between_requests(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    requests_mock.get(f"{const.OFFICIAL_API_URL}/zaehlpunkte", json=[])
+
+    client = _make_client()
+    client.zaehlpunkte()
+    client.zaehlpunkte()
+
+    token_calls = [
+        h for h in requests_mock.request_history
+        if h.url == const.OFFICIAL_TOKEN_URL
+    ]
+    assert len(token_calls) == 1
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_token_refresh_on_401(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    # First resource call returns 401, second returns success.
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte",
+        [
+            {"status_code": 401, "json": {"error": "expired"}},
+            {"status_code": 200, "json": []},
+        ],
+    )
+
+    result = _make_client().zaehlpunkte()
+
+    assert result == []
+    token_calls = [
+        h for h in requests_mock.request_history
+        if h.url == const.OFFICIAL_TOKEN_URL
+    ]
+    # Expect: initial token + one forced refresh after the 401.
+    assert len(token_calls) == 2
+
+
+@pytest.mark.usefixtures("requests_mock")
+def test_non_200_error_response_raises_query_error(requests_mock: Mocker):
+    _mock_token(requests_mock)
+    requests_mock.get(
+        f"{const.OFFICIAL_API_URL}/zaehlpunkte",
+        status_code=500,
+        text="boom",
+    )
+
+    with pytest.raises(SmartmeterQueryError) as exc_info:
+        _make_client().zaehlpunkte()
+
+    assert exc_info.value.code == 500
+
+
+# ---------------------------------------------------------------------------
+# Date coercion helpers
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (date(2026, 4, 10), "2026-04-10"),
+        (datetime(2026, 4, 10, 12, 34, 56), "2026-04-10"),
+        ("2026-04-10T00:00:00Z", "2026-04-10T00:00:00Z"),  # passthrough
+    ],
+)
+def test_format_date_helper(value, expected):
+    from wnsm.api.official_client import _format_date
+
+    assert _format_date(value) == expected
+
+
+def test_format_date_rejects_unsupported_type():
+    from wnsm.api.official_client import _format_date
+
+    with pytest.raises(TypeError):
+        _format_date(1234567890)  # type: ignore[arg-type]
+
+
+def test_messwerte_date_round_trip_via_helper():
+    today = date.today()
+    last_week = today - timedelta(days=7)
+
+    from wnsm.api.official_client import _format_date
+
+    assert _format_date(last_week) == last_week.isoformat()
+    assert _format_date(today) == today.isoformat()
+
+
+# ===========================================================================
+# Adapter tests (official -> internal shape)
+# ===========================================================================
+from wnsm.api import adapter  # noqa: E402
+
+
+_OFFICIAL_ZP = {
+    "zaehlpunktnummer": "AT0010000000000000001000000000001",
+    "zaehlpunktname": "Haushalt",
+    "anlage": {"anlage": "42", "sparte": "STROM", "typ": "TAGSTROM"},
+    "geraet": {"equipmentnummer": "E1", "geraetenummer": "G1"},
+    "idex": {
+        "customerInterface": "ENABLED",
+        "displayLocked": False,
+        "granularity": "QUARTER_HOUR",
+    },
+    "verbrauchsstelle": {
+        "haus": "Haus A",
+        "hausnummer1": "12",
+        "hausnummer2": "b",
+        "land": "AT",
+        "ort": "Wien",
+        "postleitzahl": "1010",
+        "stockwerk": "",
+        "strasse": "Ringstr.",
+        "strasseZusatz": "",
+        "tuernummer": "",
+    },
+}
+
+
+def test_adapter_zaehlpunkt_maps_core_fields():
+    internal = adapter.zaehlpunkt_to_internal(_OFFICIAL_ZP, customer_id="CUST42")
+
+    assert internal["zaehlpunktnummer"] == _OFFICIAL_ZP["zaehlpunktnummer"]
+    assert internal["customLabel"] == "Haushalt"
+    assert internal["equipmentNumber"] == "E1"
+    assert internal["geraetNumber"] == "G1"
+    assert internal["geschaeftspartner"] == "CUST42"
+    assert internal["anlage"]["typ"] == "TAGSTROM"
+    assert internal["verbrauchsstelle"]["postleitzahl"] == "1010"
+    assert internal["verbrauchsstelle"]["anlageHausnummer"] == "12b"
+    assert internal["isActive"] is True
+    assert internal["isDefault"] is True
+    assert internal["idexStatus"]["granularity"]["status"] == "QUARTER_HOUR"
+
+
+def test_adapter_translate_dict_integration():
+    """Output must round-trip through translate_dict + ATTRS_ZAEHLPUNKTE_CALL."""
+    # Load the small, HA-free helpers on demand so we don't need the full
+    # component package at import time.
+    _load_file("wnsm.utils", _WNSM_ROOT / "utils.py")
+    _load_file("wnsm.const", _WNSM_ROOT / "const.py")
+    from wnsm.utils import translate_dict
+    from wnsm.const import ATTRS_ZAEHLPUNKTE_CALL
+
+    internal = adapter.zaehlpunkt_to_internal(_OFFICIAL_ZP, customer_id="CUST42")
+    translated = translate_dict(internal, ATTRS_ZAEHLPUNKTE_CALL)
+
+    assert translated["zaehlpunktnummer"] == _OFFICIAL_ZP["zaehlpunktnummer"]
+    assert translated["customerId"] == "CUST42"
+    assert translated["label"] == "Haushalt"
+    assert translated["type"] == "TAGSTROM"
+    assert translated["zip"] == "1010"
+    assert translated["active"] is True
+
+
+def test_adapter_zaehlpunkte_list():
+    result = adapter.zaehlpunkte_to_internal(
+        [_OFFICIAL_ZP, _OFFICIAL_ZP],
+        customer_id="CUST42",
+    )
+    assert len(result) == 2
+    assert all(r["customLabel"] == "Haushalt" for r in result)
+
+
+_OFFICIAL_MESSWERTE = {
+    "zaehlpunkt": "AT0010000000000000001000000000001",
+    "zaehlwerke": [
+        {
+            "einheit": "WH",
+            "obisCode": "1-1:1.9.0",
+            "messwerte": [
+                {
+                    "messwert": 150,
+                    "qualitaet": "VAL",
+                    "zeitVon": "2026-04-10T00:00:00Z",
+                    "zeitBis": "2026-04-10T00:15:00Z",
+                },
+                {
+                    "messwert": 175,
+                    "qualitaet": "ERS",
+                    "zeitVon": "2026-04-10T00:15:00Z",
+                    "zeitBis": "2026-04-10T00:30:00Z",
+                },
+            ],
+        }
+    ],
+}
+
+
+def test_adapter_historic_data_shape():
+    historic = adapter.messwerte_to_historic_data(_OFFICIAL_MESSWERTE)
+
+    assert len(historic) == 1
+    series = historic[0]
+    assert series["obisCode"] == "1-1:1.9.0"
+    assert series["einheit"] == "WH"
+    assert len(series["messwerte"]) == 2
+    first = series["messwerte"][0]
+    assert first["value"] == 150
+    assert first["timestamp"] == "2026-04-10T00:00:00Z"
+    assert first["isEstimated"] is False
+    second = series["messwerte"][1]
+    assert second["isEstimated"] is True  # ERS != VAL
+
+
+def test_adapter_bewegungsdaten_consuming_quarter_hour():
+    bd = adapter.messwerte_to_bewegungsdaten(
+        _OFFICIAL_MESSWERTE,
+        wertetyp=const.Wertetyp.QUARTER_HOUR,
+        anlagen_typ="TAGSTROM",
+        customer_id="CUST42",
+    )
+
+    descriptor = bd["descriptor"]
+    assert descriptor["zaehlpunktnummer"] == _OFFICIAL_MESSWERTE["zaehlpunkt"]
+    assert descriptor["rolle"] == "V002"  # consuming + QH
+    assert descriptor["granularitaet"] == "QH"
+    assert descriptor["einheit"] == "WH"
+    assert descriptor["geschaeftspartnernummer"] == "CUST42"
+    assert len(bd["values"]) == 2
+
+
+def test_adapter_bewegungsdaten_feeding_daily():
+    bd = adapter.messwerte_to_bewegungsdaten(
+        _OFFICIAL_MESSWERTE,
+        wertetyp="DAY",
+        anlagen_typ="BEZUG",
+    )
+    assert bd["descriptor"]["rolle"] == "E001"  # feeding + daily
+    assert bd["descriptor"]["granularitaet"] == "D"
+
+
+def test_adapter_bewegungsdaten_handles_empty_zaehlwerke():
+    empty = {"zaehlpunkt": "AT0001", "zaehlwerke": []}
+    bd = adapter.messwerte_to_bewegungsdaten(
+        empty,
+        wertetyp=const.Wertetyp.DAY,
+        anlagen_typ="TAGSTROM",
+    )
+    assert bd["values"] == []
+    assert bd["descriptor"]["einheit"] is None
+
+
+def test_adapter_bewegungsdaten_picks_obis_match():
+    multi = {
+        "zaehlpunkt": "AT0001",
+        "zaehlwerke": [
+            {"obisCode": "1-1:1.8.0", "einheit": "WH", "messwerte": []},
+            {"obisCode": "1-1:1.9.0", "einheit": "WH", "messwerte": [
+                {"messwert": 1, "qualitaet": "VAL", "zeitVon": "x", "zeitBis": "y"}
+            ]},
+        ],
+    }
+    bd = adapter.messwerte_to_bewegungsdaten(
+        multi,
+        wertetyp="QUARTER_HOUR",
+        anlagen_typ="TAGSTROM",
+        obis_code="1-1:1.9.0",
+    )
+    assert bd["descriptor"]["obisCode"] == "1-1:1.9.0"
+    assert len(bd["values"]) == 1
+
+
+def test_adapter_messwert_emits_legacy_keys():
+    """The Importer reads ``wert``, ``zeitpunktVon`` and ``geschaetzt``;
+    :meth:`WNSMSensor.get_meter_reading_from_historic_data` reads
+    ``messwert``. Both naming conventions must be present."""
+    historic = adapter.messwerte_to_historic_data(_OFFICIAL_MESSWERTE)
+    mw = historic[0]["messwerte"][0]
+
+    # Legacy portal keys consumed by importer.py + wnsm_sensor.py
+    assert mw["wert"] == 150
+    assert mw["messwert"] == 150
+    assert mw["zeitpunktVon"] == "2026-04-10T00:00:00Z"
+    assert mw["zeitpunktBis"] == "2026-04-10T00:15:00Z"
+    assert mw["geschaetzt"] is False
+    # Estimated reading gets geschaetzt=True
+    estimated = historic[0]["messwerte"][1]
+    assert estimated["geschaetzt"] is True
+
+
+# ===========================================================================
+# Client factory + _OfficialSmartmeterShim tests
+# ===========================================================================
+from wnsm.api import client_factory  # noqa: E402
+from wnsm.api.client_factory import (  # noqa: E402
+    _OfficialSmartmeterShim,
+    make_client,
+)
+from wnsm.const import (  # noqa: E402
+    AUTH_METHOD_LEGACY,
+    AUTH_METHOD_OFFICIAL,
+    CONF_API_KEY,
+    CONF_AUTH_METHOD,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_CUSTOMER_ID,
+    CONF_WEB_PROFILE_ID,
+)
+
+
+def _official_entry() -> Dict[str, Any]:
+    return {
+        CONF_AUTH_METHOD: AUTH_METHOD_OFFICIAL,
+        CONF_CLIENT_ID: CLIENT_ID,
+        CONF_CLIENT_SECRET: CLIENT_SECRET,
+        CONF_API_KEY: API_KEY,
+        CONF_WEB_PROFILE_ID: "profile-1",
+        CONF_CUSTOMER_ID: "CUST42",
+    }
+
+
+def test_make_client_returns_shim_for_official():
+    shim = make_client(_official_entry())
+    assert isinstance(shim, _OfficialSmartmeterShim)
+    assert shim.customer_id == "CUST42"
+    assert isinstance(shim.client, OfficialSmartmeter)
+    assert shim.client.client_id == CLIENT_ID
+    assert shim.client.api_key == API_KEY
+    assert shim.client.web_profile_id == "profile-1"
+
+
+def test_make_client_returns_legacy_smartmeter_for_legacy():
+    from wnsm.api.client import Smartmeter as _StubSmartmeterRef
+
+    legacy_entry: Dict[str, Any] = {
+        CONF_AUTH_METHOD: AUTH_METHOD_LEGACY,
+        "username": "user",
+        "password": "pass",  # noqa: S106 - test fixture
+    }
+    client = make_client(legacy_entry)
+    assert isinstance(client, _StubSmartmeterRef)
+    # Stub records the positional args so we can prove the factory
+    # forwarded the right fields.
+    assert client.args == ("user", "pass")
+
+
+def test_make_client_defaults_to_legacy_when_method_missing():
+    """Entries created before the auth_method key was introduced must
+    still resolve to the legacy scraper – otherwise upgrading the
+    integration would break every existing install."""
+    from wnsm.api.client import Smartmeter as _StubSmartmeterRef
+
+    entry: Dict[str, Any] = {"username": "u", "password": "p"}  # noqa: S106
+    client = make_client(entry)
+    assert isinstance(client, _StubSmartmeterRef)
+
+
+class _FakeOfficialClient:
+    """In-memory stand-in for :class:`OfficialSmartmeter`.
+
+    Captures the calls the shim makes and returns canned responses so
+    we can assert on both sides of the translation without touching the
+    network. Implements just the slice of :class:`OfficialSmartmeter`
+    the shim actually invokes.
+    """
+
+    def __init__(self, *, zaehlpunkte_response: Any, messwerte_response: Any):
+        self._zaehlpunkte_response = zaehlpunkte_response
+        self._messwerte_response = messwerte_response
+        self.login_calls = 0
+        self.zaehlpunkte_calls = 0
+        self.messwerte_calls: list[Dict[str, Any]] = []
+
+    def login(self) -> str:
+        self.login_calls += 1
+        return "tok"
+
+    def zaehlpunkte(self) -> list[Dict[str, Any]]:
+        self.zaehlpunkte_calls += 1
+        return self._zaehlpunkte_response
+
+    def messwerte(self, **kwargs: Any) -> Any:
+        self.messwerte_calls.append(kwargs)
+        return self._messwerte_response
+
+
+def _make_shim(
+    *,
+    zaehlpunkte_response: Any = None,
+    messwerte_response: Any = None,
+    customer_id: Optional[str] = "CUST42",
+) -> tuple[_OfficialSmartmeterShim, _FakeOfficialClient]:
+    fake = _FakeOfficialClient(
+        zaehlpunkte_response=zaehlpunkte_response or [_OFFICIAL_ZP],
+        messwerte_response=messwerte_response or _OFFICIAL_MESSWERTE,
+    )
+    shim = _OfficialSmartmeterShim(client=fake, customer_id=customer_id)
+    return shim, fake
+
+
+def test_shim_login_delegates_to_client():
+    shim, fake = _make_shim()
+    assert shim.login() == "tok"
+    assert fake.login_calls == 1
+
+
+def test_shim_zaehlpunkte_wraps_in_legacy_contract():
+    shim, fake = _make_shim()
+
+    contracts = shim.zaehlpunkte()
+
+    assert fake.zaehlpunkte_calls == 1
+    assert len(contracts) == 1
+    contract = contracts[0]
+    assert contract["geschaeftspartner"] == "CUST42"
+    assert len(contract["zaehlpunkte"]) == 1
+    zp = contract["zaehlpunkte"][0]
+    assert zp["zaehlpunktnummer"] == _OFFICIAL_ZP["zaehlpunktnummer"]
+    assert zp["isActive"] is True
+    assert zp["anlage"]["typ"] == "TAGSTROM"
+
+
+def test_shim_historical_data_returns_single_dict():
+    shim, fake = _make_shim()
+
+    result = shim.historical_data(
+        zaehlpunktnummer="AT0010000000000000001000000000001",
+        date_from=date(2026, 4, 10),
+        date_until=date(2026, 4, 11),
+        valuetype=const.ValueType.METER_READ,
+    )
+
+    # Legacy portal API returns a single {obisCode, einheit, messwerte}
+    # object per request. The shim must flatten the zaehlwerke list.
+    assert isinstance(result, dict)
+    assert result["obisCode"] == "1-1:1.9.0"
+    assert result["einheit"] == "WH"
+    assert len(result["messwerte"]) == 2
+    # The importer and sensor expect legacy key names on each entry.
+    assert result["messwerte"][0]["messwert"] == 150
+    assert result["messwerte"][0]["wert"] == 150
+
+    # And the call should have been routed to the per-zp messwerte
+    # endpoint with the right query parameters.
+    assert len(fake.messwerte_calls) == 1
+    call = fake.messwerte_calls[0]
+    assert call["zaehlpunkt"] == "AT0010000000000000001000000000001"
+    assert call["wertetyp"] is const.Wertetyp.METER_READ
+
+
+def test_shim_historical_data_handles_empty_response():
+    shim, _ = _make_shim(
+        messwerte_response={"zaehlpunkt": "AT0001", "zaehlwerke": []}
+    )
+
+    result = shim.historical_data(
+        zaehlpunktnummer="AT0001",
+        date_from=date(2026, 4, 10),
+        date_until=date(2026, 4, 11),
+    )
+
+    assert result == {"obisCode": None, "einheit": None, "messwerte": []}
+
+
+def test_shim_historical_data_requires_zaehlpunkt():
+    shim, _ = _make_shim()
+    with pytest.raises(ValueError):
+        shim.historical_data()
+
+
+def test_shim_bewegungsdaten_routes_through_adapter():
+    shim, fake = _make_shim()
+
+    bd = shim.bewegungsdaten(
+        zaehlpunktnummer="AT0010000000000000001000000000001",
+        date_from=date(2026, 4, 10),
+        date_until=date(2026, 4, 11),
+        valuetype=const.ValueType.QUARTER_HOUR,
+    )
+
+    descriptor = bd["descriptor"]
+    assert descriptor["zaehlpunktnummer"] == _OFFICIAL_MESSWERTE["zaehlpunkt"]
+    # TAGSTROM (consuming) + quarter-hour → V002
+    assert descriptor["rolle"] == "V002"
+    assert descriptor["granularitaet"] == "QH"
+    assert descriptor["geschaeftspartnernummer"] == "CUST42"
+    assert len(bd["values"]) == 2
+    # Importer reads wert/zeitpunktVon/geschaetzt – those must survive
+    # the adapter round-trip end-to-end.
+    first = bd["values"][0]
+    assert first["wert"] == 150
+    assert first["zeitpunktVon"] == "2026-04-10T00:00:00Z"
+    assert first["geschaetzt"] is False
+
+    # The shim should have pre-fetched zaehlpunkte to derive the role.
+    assert fake.zaehlpunkte_calls == 1
+
+
+def test_shim_bewegungsdaten_requires_zaehlpunkt():
+    shim, _ = _make_shim()
+    with pytest.raises(ValueError):
+        shim.bewegungsdaten()
+
+
+def test_shim_bewegungsdaten_caches_zaehlpunkte_lookup():
+    """The role-lookup for bewegungsdaten calls should reuse the cached
+    zaehlpunkte list instead of hitting the API again per request."""
+    shim, fake = _make_shim()
+
+    shim.bewegungsdaten(
+        zaehlpunktnummer="AT0010000000000000001000000000001",
+        date_from=date(2026, 4, 10),
+        date_until=date(2026, 4, 11),
+    )
+    shim.bewegungsdaten(
+        zaehlpunktnummer="AT0010000000000000001000000000001",
+        date_from=date(2026, 4, 10),
+        date_until=date(2026, 4, 11),
+    )
+
+    assert fake.zaehlpunkte_calls == 1  # cached, not re-fetched
+    assert len(fake.messwerte_calls) == 2
+
+
+def test_shim_coerces_value_type_to_wertetyp():
+    assert (
+        _OfficialSmartmeterShim._coerce_wertetyp(const.ValueType.DAY)
+        is const.Wertetyp.DAY
+    )
+    assert (
+        _OfficialSmartmeterShim._coerce_wertetyp(const.ValueType.METER_READ)
+        is const.Wertetyp.METER_READ
+    )
+    assert (
+        _OfficialSmartmeterShim._coerce_wertetyp(None)
+        is const.Wertetyp.QUARTER_HOUR
+    )
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["base_information", "verbrauch", "verbrauchRaw", "consumptions"],
+)
+def test_shim_unsupported_methods_raise(method: str):
+    shim, _ = _make_shim()
+    with pytest.raises(NotImplementedError) as exc_info:
+        getattr(shim, method)()
+    # The error message must name the missing method so users know
+    # exactly what the official API lacks.
+    assert method in str(exc_info.value)
+
+
+def test_shim_is_login_expired_tracks_internal_token():
+    shim, _ = _make_shim()
+    # Fake client never populated ``_token`` – we consider that expired.
+    assert shim.is_login_expired() is True


### PR DESCRIPTION
## Summary

Adds support for the official WN_SMART_METER_API (OAuth2) as an alternative to the legacy username/password HTML-scraping method. Users can now choose their preferred authentication method in the config flow.

## Key Changes

**New Components:**
- official_client.py - Client for the public OAuth2-secured Wiener Netze API
- adapter.py - Translates official API responses to legacy method shape  
- client_factory.py - Factory pattern to return appropriate client based on config

**Modified Files:**
- config_flow.py - Add OAuth2 credential fields and method selection UI
- AsyncSmartmeter.py - Support both client implementations transparently
- const.py - New config constants for OAuth2 parameters
- api/constants.py - API endpoints, token URLs, and type definitions
- sensor.py - Support official API configuration
- translations/en.json - New UI labels for OAuth2 fields

**Tests:**
  - test_official_client.py - 47 comprehensive tests covering:
  - OAuth2 authentication and token refresh
  - API endpoint calls and response parsing
  - Data adaptation from official to legacy format
  - Edge cases and error handling

## Test Results

✅ All tests passing: 47/47

## Backward Compatibility

Existing legacy method configs continue to work without any changes. This is purely additive functionality.